### PR TITLE
#16 remove --contexts in systemverilog

### DIFF
--- a/examples/apbDecode/systemVerilog/apbDecode.sv
+++ b/examples/apbDecode/systemVerilog/apbDecode.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=apbDecode --parentModule
+// GENERATED_CODE_PARAM --block=apbDecode
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
 //module as defined by block: apbDecode
 module apbDecode
@@ -89,5 +89,5 @@ assign apbReg.pready  = pready;
 assign apbReg.prdata  = prdata;
 assign apbReg.pslverr = pslverr;
 
-endmodule // apbDecode
+endmodule: apbDecode
 // GENERATED_CODE_END

--- a/examples/apbDecode/systemVerilog/apbDecode_package.sv
+++ b/examples/apbDecode/systemVerilog/apbDecode_package.sv
@@ -1,9 +1,8 @@
 
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
-// GENERATED_CODE_PARAM --contexts=apbDecode.yaml
+// GENERATED_CODE_PARAM --context=apbDecode.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package apbDecode_package;
-//constants as defined by the scope of the following context(s): ('apbDecode.yaml',)
 //         ASIZE =                             'd29;  // The size of A
 localparam ASIZE =                           32'h0000_001D;  // The size of A
 //         DWORD =                             'd32;  // size of a double word

--- a/examples/apbDecode/systemVerilog/cpu.sv
+++ b/examples/apbDecode/systemVerilog/cpu.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=cpu --parentModule
+// GENERATED_CODE_PARAM --block=cpu
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: cpu
 module cpu
@@ -12,5 +12,7 @@ import apbDecode_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // cpu
+
 // GENERATED_CODE_END
+
+endmodule : cpu

--- a/examples/apbDecode/systemVerilog/someRapper.sv
+++ b/examples/apbDecode/systemVerilog/someRapper.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=someRapper --parentModule
+// GENERATED_CODE_PARAM --block=someRapper
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: someRapper
 module someRapper
@@ -34,5 +34,7 @@ blockB uBlockB (
     .rst_n (rst_n)
 );
 
-endmodule // someRapper
+
 // GENERATED_CODE_END
+
+endmodule : someRapper

--- a/examples/apbDecode/systemVerilog/top.sv
+++ b/examples/apbDecode/systemVerilog/top.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=top --parentModule
+// GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
@@ -24,5 +24,7 @@ someRapper uSomeRapper (
     .rst_n (rst_n)
 );
 
-endmodule // top
+
 // GENERATED_CODE_END
+
+endmodule : top

--- a/examples/axiDemo/systemVerilog/axiDemo_package.sv
+++ b/examples/axiDemo/systemVerilog/axiDemo_package.sv
@@ -1,11 +1,10 @@
 
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
-// GENERATED_CODE_PARAM --contexts=axiDemo.yaml
+// GENERATED_CODE_PARAM --context=axiDemo.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package axiDemo_package;
 // Generated Import package statement(s)
 import axiStd_package::*;
-//constants as defined by the scope of the following context(s): ('axiDemo.yaml',)
 //         AXI_ADDRESS_WIDTH =                 'd32;  // The width of the AXI address busses
 localparam AXI_ADDRESS_WIDTH =               32'h0000_0020;  // The width of the AXI address busses
 //         AXI_DATA_WIDTH =                    'd32;  // The width of the AXI data busses

--- a/examples/axiDemo/systemVerilog/axiStd_package.sv
+++ b/examples/axiDemo/systemVerilog/axiStd_package.sv
@@ -1,9 +1,8 @@
 
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
-// GENERATED_CODE_PARAM --contexts=axiStd.yaml
+// GENERATED_CODE_PARAM --context=axiStd.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package axiStd_package;
-//constants as defined by the scope of the following context(s): ('axiStd.yaml',)
 
 // types
 typedef logic[4-1:0] _axiIdT; //Type for axi ID tags. Used for ARID, RID, AWID, BID.

--- a/examples/axiDemo/systemVerilog/consumer.sv
+++ b/examples/axiDemo/systemVerilog/consumer.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=consumer --parentModule
+// GENERATED_CODE_PARAM --block=consumer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: consumer
 module consumer
@@ -19,5 +19,7 @@ import axiDemo_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // consumer
+
 // GENERATED_CODE_END
+
+endmodule: consumer

--- a/examples/axiDemo/systemVerilog/producer.sv
+++ b/examples/axiDemo/systemVerilog/producer.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=producer --parentModule
+// GENERATED_CODE_PARAM --block=producer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: producer
 module producer
@@ -19,5 +19,7 @@ import axiDemo_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // producer
+
 // GENERATED_CODE_END
+
+endmodule: producer

--- a/examples/axiDemo/systemVerilog/top.sv
+++ b/examples/axiDemo/systemVerilog/top.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=top --parentModule
+// GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
@@ -45,5 +45,6 @@ consumer uConsumer (
     .rst_n (rst_n)
 );
 
-endmodule // top
+
 // GENERATED_CODE_END
+endmodule: top

--- a/examples/hierInclude/systemVerilog/b/blockBX.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBX.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockBX --parentModule
+// GENERATED_CODE_PARAM --block=blockBX
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBX
 module blockBX
@@ -16,5 +16,7 @@ import hierIncludeB_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockBX
+
 // GENERATED_CODE_END
+
+endmodule: blockBX

--- a/examples/hierInclude/systemVerilog/b/blockBY.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBY.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockBY --parentModule
+// GENERATED_CODE_PARAM --block=blockBY
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBY
 module blockBY
@@ -12,5 +12,7 @@ import hierIncludeB_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockBY
+
 // GENERATED_CODE_END
+
+endmodule: blockBY

--- a/examples/hierInclude/systemVerilog/b/blockBZ.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBZ.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockBZ --parentModule
+// GENERATED_CODE_PARAM --block=blockBZ
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBZ
 module blockBZ
@@ -12,5 +12,7 @@ import hierIncludeB_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockBZ
+
 // GENERATED_CODE_END
+
+endmodule: blockBZ

--- a/examples/hierInclude/systemVerilog/b/hierIncludeBInclude_package.sv
+++ b/examples/hierInclude/systemVerilog/b/hierIncludeBInclude_package.sv
@@ -1,7 +1,6 @@
-// GENERATED_CODE_PARAM --contexts b/hierIncludeBInclude.yaml
+// GENERATED_CODE_PARAM --context b/hierIncludeBInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeBInclude_package;
-//constants as defined by the scope of the following context(s): ('b/hierIncludeBInclude.yaml',)
 //         B_ANOTHER_SIZE =                     'd9;  // The size for b another size
 localparam B_ANOTHER_SIZE =                   32'h0000_0009;  // The size for b another size
 

--- a/examples/hierInclude/systemVerilog/b/hierIncludeB_package.sv
+++ b/examples/hierInclude/systemVerilog/b/hierIncludeB_package.sv
@@ -1,11 +1,10 @@
-// GENERATED_CODE_PARAM --contexts b/hierIncludeB.yaml
+// GENERATED_CODE_PARAM --context b/hierIncludeB.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeB_package;
 // Generated Import package statement(s)
 import hierIncludeTop_package::*;
 import hierInclude_package::*;
 import hierIncludeBInclude_package::*;
-//constants as defined by the scope of the following context(s): ('b/hierIncludeB.yaml',)
 
 // types
 typedef logic[9-1:0] bSizeT; //A type from an include sizing from constant B_ANOTHER_SIZE

--- a/examples/hierInclude/systemVerilog/blockA.sv
+++ b/examples/hierInclude/systemVerilog/blockA.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockA --parentModule
+// GENERATED_CODE_PARAM --block=blockA
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockA
 module blockA
@@ -13,5 +13,7 @@ import hierInclude_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockA
+
 // GENERATED_CODE_END
+
+endmodule: blockA

--- a/examples/hierInclude/systemVerilog/blockB.sv
+++ b/examples/hierInclude/systemVerilog/blockB.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockB --parentModule 
+// GENERATED_CODE_PARAM --block=blockB
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockB
 module blockB
@@ -37,5 +37,7 @@ blockBZ uBlockBZ (
     .rst_n (rst_n)
 );
 
-endmodule // blockB
+
 // GENERATED_CODE_END
+
+endmodule: blockB

--- a/examples/hierInclude/systemVerilog/blockC.sv
+++ b/examples/hierInclude/systemVerilog/blockC.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockC --parentModule 
+// GENERATED_CODE_PARAM --block=blockC
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockC
 module blockC
@@ -37,5 +37,7 @@ blockCZ uBlockCZ (
     .rst_n (rst_n)
 );
 
-endmodule // blockC
+
 // GENERATED_CODE_END
+
+endmodule: blockC

--- a/examples/hierInclude/systemVerilog/c/blockCX.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCX.sv
@@ -91,4 +91,4 @@ always_ff @(posedge clk or negedge rst_n) begin
     end
 end
 
-endmodule // blockCX
+endmodule: blockCX

--- a/examples/hierInclude/systemVerilog/c/blockCY.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCY.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockCY --parentModule
+// GENERATED_CODE_PARAM --block=blockCY
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockCY
 module blockCY
@@ -12,5 +12,7 @@ import hierIncludeC_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockCY
+
 // GENERATED_CODE_END
+
+endmodule: blockCY

--- a/examples/hierInclude/systemVerilog/c/blockCZ.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCZ.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockCZ --parentModule
+// GENERATED_CODE_PARAM --block=blockCZ
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockCZ
 module blockCZ
@@ -12,5 +12,7 @@ import hierIncludeC_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // blockCZ
+
 // GENERATED_CODE_END
+
+endmodule: blockCZ

--- a/examples/hierInclude/systemVerilog/c/hierIncludeCInclude_package.sv
+++ b/examples/hierInclude/systemVerilog/c/hierIncludeCInclude_package.sv
@@ -1,7 +1,6 @@
-// GENERATED_CODE_PARAM --contexts c/hierIncludeCInclude.yaml
+// GENERATED_CODE_PARAM --context c/hierIncludeCInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeCInclude_package;
-//constants as defined by the scope of the following context(s): ('c/hierIncludeCInclude.yaml',)
 //         C_ANOTHER_SIZE =                    'd10;  // The size of c another size
 localparam C_ANOTHER_SIZE =                  32'h0000_000A;  // The size of c another size
 //         D_SIZE =                             'd3;  // The size for d

--- a/examples/hierInclude/systemVerilog/c/hierIncludeC_package.sv
+++ b/examples/hierInclude/systemVerilog/c/hierIncludeC_package.sv
@@ -1,11 +1,10 @@
-// GENERATED_CODE_PARAM --contexts c/hierIncludeC.yaml
+// GENERATED_CODE_PARAM --context c/hierIncludeC.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeC_package;
 // Generated Import package statement(s)
 import hierIncludeTop_package::*;
 import hierInclude_package::*;
 import hierIncludeCInclude_package::*;
-//constants as defined by the scope of the following context(s): ('c/hierIncludeC.yaml',)
 
 // types
 typedef logic[10-1:0] cSizeT; //A type from an include sizing from constant C_ANOTHER_SIZE

--- a/examples/hierInclude/systemVerilog/hierIncludeNestedTop_package.sv
+++ b/examples/hierInclude/systemVerilog/hierIncludeNestedTop_package.sv
@@ -1,7 +1,6 @@
-// GENERATED_CODE_PARAM --contexts hierIncludeNestedTop.yaml
+// GENERATED_CODE_PARAM --context hierIncludeNestedTop.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeNestedTop_package;
-//constants as defined by the scope of the following context(s): ('hierIncludeNestedTop.yaml',)
 //         YET_ANOTHER_SIZE =                   'd8;  // The size of yet another size
 localparam YET_ANOTHER_SIZE =                 32'h0000_0008;  // The size of yet another size
 

--- a/examples/hierInclude/systemVerilog/hierIncludeTop_package.sv
+++ b/examples/hierInclude/systemVerilog/hierIncludeTop_package.sv
@@ -1,9 +1,8 @@
-// GENERATED_CODE_PARAM --contexts hierIncludeTop.yaml
+// GENERATED_CODE_PARAM --context hierIncludeTop.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeTop_package;
 // Generated Import package statement(s)
 import hierIncludeNestedTop_package::*;
-//constants as defined by the scope of the following context(s): ('hierIncludeTop.yaml',)
 //         ANOTHER_SIZE =                       'd4;  // The size for another size
 localparam ANOTHER_SIZE =                     32'h0000_0004;  // The size for another size
 

--- a/examples/hierInclude/systemVerilog/hierInclude_package.sv
+++ b/examples/hierInclude/systemVerilog/hierInclude_package.sv
@@ -1,10 +1,9 @@
-// GENERATED_CODE_PARAM --contexts hierInclude.yaml
+// GENERATED_CODE_PARAM --context hierInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierInclude_package;
 // Generated Import package statement(s)
 import hierIncludeNestedTop_package::*;
 import hierIncludeTop_package::*;
-//constants as defined by the scope of the following context(s): ('hierInclude.yaml',)
 //         ASIZE =                              'd7;  // The size of A
 localparam ASIZE =                            32'h0000_0007;  // The size of A
 //         ASIZE2 =                            'd11;  // The size of A + included constant another size

--- a/examples/hierInclude/systemVerilog/top.sv
+++ b/examples/hierInclude/systemVerilog/top.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=top --parentModule
+// GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
@@ -35,5 +35,7 @@ blockC uBlockC (
     .rst_n (rst_n)
 );
 
-endmodule // top
+
 // GENERATED_CODE_END
+
+endmodule: top

--- a/examples/inAndOut/systemVerilog/inAndOut.sv
+++ b/examples/inAndOut/systemVerilog/inAndOut.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=inAndOut --parentModule
+// GENERATED_CODE_PARAM --block=inAndOut
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: inAndOut
 module inAndOut
@@ -17,5 +17,7 @@ import inAndOut_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // inAndOut
+
 // GENERATED_CODE_END
+
+endmodule: inAndOut

--- a/examples/inAndOut/systemVerilog/inAndOut_package.sv
+++ b/examples/inAndOut/systemVerilog/inAndOut_package.sv
@@ -1,9 +1,8 @@
 
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
-// GENERATED_CODE_PARAM --contexts=inAndOut.yaml
+// GENERATED_CODE_PARAM --context=inAndOut.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package inAndOut_package;
-//constants as defined by the scope of the following context(s): ('inAndOut.yaml',)
 //         ASIZE =                              'd1;  // The size of A
 localparam ASIZE =                            32'h0000_0001;  // The size of A
 //         ASIZE2 =                             'd2;  // The size of A+1

--- a/examples/mixed/systemVerilog/apbDecode.sv
+++ b/examples/mixed/systemVerilog/apbDecode.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=apbDecode --parentModule
+// GENERATED_CODE_PARAM --block=apbDecode
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
 //module as defined by block: apbDecode
 module apbDecode
@@ -89,5 +89,5 @@ assign apbReg.pready  = pready;
 assign apbReg.prdata  = prdata;
 assign apbReg.pslverr = pslverr;
 
-endmodule // apbDecode
+endmodule: apbDecode
 // GENERATED_CODE_END

--- a/examples/mixed/systemVerilog/blockA.sv
+++ b/examples/mixed/systemVerilog/blockA.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockA --parentModule
+// GENERATED_CODE_PARAM --block=blockA
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockA
 module blockA
@@ -26,5 +26,7 @@ blockARegs #(.APB_ADDR_MASK('hff_ffff)) uBlockARegs (
     .rst_n (rst_n)
 );
 
-endmodule // blockA
+
 // GENERATED_CODE_END
+
+endmodule: blockA

--- a/examples/mixed/systemVerilog/blockB.sv
+++ b/examples/mixed/systemVerilog/blockB.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockB --parentModule
+// GENERATED_CODE_PARAM --block=blockB
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockB
 module blockB
@@ -119,5 +119,7 @@ memory_sp #(.DEPTH(BSIZE), .data_t(nestedSt)) uBlockBTableSP (
     .clk (clk)
 );
 
-endmodule // blockB
+
 // GENERATED_CODE_END
+
+endmodule: blockB

--- a/examples/mixed/systemVerilog/blockC.sv
+++ b/examples/mixed/systemVerilog/blockC.sv
@@ -15,5 +15,5 @@ import mixedBlockC_package::*;
 
 // GENERATED_CODE_END
 
-endmodule
+endmodule: blockC
 

--- a/examples/mixed/systemVerilog/blockD.sv
+++ b/examples/mixed/systemVerilog/blockD.sv
@@ -22,4 +22,4 @@ import mixedBlockC_package::*;
 
 // GENERATED_CODE_END
 
-endmodule
+endmodule: blockD

--- a/examples/mixed/systemVerilog/blockF.sv
+++ b/examples/mixed/systemVerilog/blockF.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=blockF --parentModule
+// GENERATED_CODE_PARAM --block=blockF
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockF
 module blockF
@@ -30,5 +30,7 @@ memory_dp #(.DEPTH(bob), .data_t(seeSt)) uTest (
     .clk (clk)
 );
 
-endmodule // blockF
+
 // GENERATED_CODE_END
+
+endmodule: blockF

--- a/examples/mixed/systemVerilog/cpu.sv
+++ b/examples/mixed/systemVerilog/cpu.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=cpu --parentModule
+// GENERATED_CODE_PARAM --block=cpu
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: cpu
 module cpu
@@ -12,5 +12,7 @@ import mixed_package::*;
     // Interface Instances, needed for between instanced modules inside this module
 
 // Instances
-endmodule // cpu
+
 // GENERATED_CODE_END
+
+endmodule: cpu

--- a/examples/mixed/systemVerilog/mixedBlockC_package.sv
+++ b/examples/mixed/systemVerilog/mixedBlockC_package.sv
@@ -1,7 +1,6 @@
-// GENERATED_CODE_PARAM --contexts mixedBlockC.yaml
+// GENERATED_CODE_PARAM --context mixedBlockC.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixedBlockC_package;
-//constants as defined by the scope of the following context(s): ('mixedBlockC.yaml',)
 //         CSIZE =                              'd2;  // The size of C
 localparam CSIZE =                            32'h0000_0002;  // The size of C
 //         CSIZE_PLUS =                         'd3;  // The size of C plus 1

--- a/examples/mixed/systemVerilog/mixedEncoder_package.sv
+++ b/examples/mixed/systemVerilog/mixedEncoder_package.sv
@@ -2,7 +2,7 @@ package mixedEncoderPackage;
 
     import mixed_package::*;
 
-    // GENERATED_CODE_PARAM --contexts=mixed.yaml
+    // GENERATED_CODE_PARAM --context=mixed.yaml
     // GENERATED_CODE_BEGIN --template=encoder
 
     function automatic opcodeTagT opcodeEnAEncoderEncode (opcodeTagT tag, opcodeEnumT tagType);

--- a/examples/mixed/systemVerilog/mixedInclude_package.sv
+++ b/examples/mixed/systemVerilog/mixedInclude_package.sv
@@ -1,9 +1,8 @@
-// GENERATED_CODE_PARAM --contexts mixedInclude.yaml
+// GENERATED_CODE_PARAM --context mixedInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixedInclude_package;
 // Generated Import package statement(s)
 import mixedNestedInclude_package::*;
-//constants as defined by the scope of the following context(s): ('mixedInclude.yaml',)
 //         BSIZE =                             'd10;  // The size of B, used for memory wordlines
 localparam BSIZE =                           32'h0000_000A;  // The size of B, used for memory wordlines
 //         BSIZE_LOG2 =                         'd4;  // The size of B, used for memory wordlines log 2

--- a/examples/mixed/systemVerilog/mixedNestedInclude_package.sv
+++ b/examples/mixed/systemVerilog/mixedNestedInclude_package.sv
@@ -1,7 +1,6 @@
-// GENERATED_CODE_PARAM --contexts mixedNestedInclude.yaml
+// GENERATED_CODE_PARAM --context mixedNestedInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixedNestedInclude_package;
-//constants as defined by the scope of the following context(s): ('mixedNestedInclude.yaml',)
 //         DSIZE =                              'd1;  // The size of D
 localparam DSIZE =                            32'h0000_0001;  // The size of D
 //         DSIZE2 =                             'd2;  // The size of D2

--- a/examples/mixed/systemVerilog/mixed_package.sv
+++ b/examples/mixed/systemVerilog/mixed_package.sv
@@ -1,11 +1,10 @@
-// GENERATED_CODE_PARAM --contexts mixed.yaml
+// GENERATED_CODE_PARAM --context mixed.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixed_package;
 // Generated Import package statement(s)
 import mixedBlockC_package::*;
 import mixedNestedInclude_package::*;
 import mixedInclude_package::*;
-//constants as defined by the scope of the following context(s): ('mixed.yaml',)
 //         ASIZE =                              'd1;  // The size of A
 localparam ASIZE =                            32'h0000_0001;  // The size of A
 //         ASIZE2 =                             'd2;  // The size of A+1

--- a/examples/mixed/systemVerilog/threeCs.sv
+++ b/examples/mixed/systemVerilog/threeCs.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=threeCs --parentModule
+// GENERATED_CODE_PARAM --block=threeCs
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: threeCs
 module threeCs
@@ -32,5 +32,7 @@ blockC uBlockC2 (
     .rst_n (rst_n)
 );
 
-endmodule // threeCs
+
 // GENERATED_CODE_END
+
+endmodule: threeCs

--- a/examples/mixed/systemVerilog/top.sv
+++ b/examples/mixed/systemVerilog/top.sv
@@ -1,4 +1,4 @@
-// GENERATED_CODE_PARAM --block=top --parentModule
+// GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
@@ -55,5 +55,7 @@ apbDecode uAPBDecode (
     .rst_n (rst_n)
 );
 
-endmodule // top
+
 // GENERATED_CODE_END
+
+endmodule: top

--- a/examples/simple/rtl/pipe/pipe.sv
+++ b/examples/simple/rtl/pipe/pipe.sv
@@ -1,5 +1,7 @@
 //copyright Arch2Code authors 2024
 
-// GENERATED_CODE_PARAM --block=pipe --parentModule
+// GENERATED_CODE_PARAM --block=pipe
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 // GENERATED_CODE_END
+
+endmodule: pipe

--- a/examples/simple/rtl/pipe/pipe_package.sv
+++ b/examples/simple/rtl/pipe/pipe_package.sv
@@ -1,5 +1,5 @@
 
 // copyright Arch2Code authors 2024
-// GENERATED_CODE_PARAM --contexts=pipe/pipe.yaml
+// GENERATED_CODE_PARAM --context=pipe/pipe.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 // GENERATED_CODE_END

--- a/examples/simple/rtl/simple/consumer.sv
+++ b/examples/simple/rtl/simple/consumer.sv
@@ -1,5 +1,7 @@
 //copyright Arch2Code authors 2024
 
-// GENERATED_CODE_PARAM --block=consumer --parentModule
+// GENERATED_CODE_PARAM --block=consumer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 // GENERATED_CODE_END
+
+endmodule: consumer

--- a/examples/simple/rtl/simple/producer.sv
+++ b/examples/simple/rtl/simple/producer.sv
@@ -1,5 +1,7 @@
 //copyright Arch2Code authors 2024
 
-// GENERATED_CODE_PARAM --block=producer --parentModule
+// GENERATED_CODE_PARAM --block=producer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 // GENERATED_CODE_END
+
+endmodule: producer

--- a/examples/simple/rtl/simple/simple.sv
+++ b/examples/simple/rtl/simple/simple.sv
@@ -1,5 +1,7 @@
 //copyright Arch2Code authors 2024
 
-// GENERATED_CODE_PARAM --block=simple --parentModule
+// GENERATED_CODE_PARAM --block=simple
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 // GENERATED_CODE_END
+
+endmodule: simple

--- a/examples/simple/rtl/simple/simple_package.sv
+++ b/examples/simple/rtl/simple/simple_package.sv
@@ -1,5 +1,5 @@
 
 // copyright Arch2Code authors 2024
-// GENERATED_CODE_PARAM --contexts=simple/simple.yaml
+// GENERATED_CODE_PARAM --context=simple/simple.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 // GENERATED_CODE_END

--- a/pysrc/systemVerilogGenerator.py
+++ b/pysrc/systemVerilogGenerator.py
@@ -35,14 +35,11 @@ class systemVerilogGenerator:
         fileName = args.file
         self.code = codeText(fileName, "//")
         data = None
-        parentModule = None
         importPackages = None
         context = None
         if not self.code.sections:
             # Gracefully skip files that do not have the appropriate GENERATED_CODE_ comments in them
             return
-        if self.code.params.parentModule:
-            parentModule = self.code.params.parentModule
         if self.code.params.importPackages:
             importPackages = self.code.params.importPackages
         if self.code.params.block and self.code.params.context:
@@ -70,7 +67,6 @@ class systemVerilogGenerator:
 
         parser = argparse.ArgumentParser(description="SystemVerilog generated code parser", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-        data['parentModule']    = parentModule
         data['importPackages']  = importPackages
         data['context']         = context
         data['fileName']        = fileName

--- a/pysrc/systemVerilogGenerator.py
+++ b/pysrc/systemVerilogGenerator.py
@@ -37,7 +37,7 @@ class systemVerilogGenerator:
         data = None
         parentModule = None
         importPackages = None
-        contexts = None
+        context = None
         if not self.code.sections:
             # Gracefully skip files that do not have the appropriate GENERATED_CODE_ comments in them
             return
@@ -45,25 +45,25 @@ class systemVerilogGenerator:
             parentModule = self.code.params.parentModule
         if self.code.params.importPackages:
             importPackages = self.code.params.importPackages
-        if self.code.params.block and self.code.params.contexts:
+        if self.code.params.block and self.code.params.context:
             qualBlock = prj.getQualBlock( self.code.block )
             data = prj.getBlockData(qualBlock, self.instances)
             if not data:
                 printError(f"In {fileName}, the block ({self.code.block}) specified in GENERATED_CODE_PARAM is either wrong or out of scope. Check the block is listed in your instances list")
                 exit(warningAndErrorReport())
-            contexts = self.code.params.contexts
-            data.update(prj.getContextData(contexts, self.dataTypeMappings))
+            context = self.code.params.context
+            data.update(prj.getContextData(context, self.dataTypeMappings))
         elif self.code.params.block:
             qualBlock = prj.getQualBlock( self.code.block )
             data = prj.getBlockData(qualBlock, self.instances)
             if not data:
                 printError(f"In {fileName}, the block ({self.code.block}) specified in GENERATED_CODE_PARAM is either wrong or out of scope. Check the block is listed in your instances list")
                 exit(warningAndErrorReport())
-        elif self.code.params.contexts:
-            contexts = self.code.params.contexts
-            data = prj.getContextData(contexts, self.dataTypeMappings)
+        elif self.code.params.context:
+            context = self.code.params.context
+            data = prj.getContextData(context, self.dataTypeMappings)
         else:
-            contexts = 'No context specified in GENERATED_CODE_PARAM'
+            context = 'No context specified in GENERATED_CODE_PARAM'
         if not data:
             printError(f"In {fileName} there was no context or block specified in GENERATED_CODE_PARAM")
             exit(warningAndErrorReport())
@@ -72,7 +72,7 @@ class systemVerilogGenerator:
 
         data['parentModule']    = parentModule
         data['importPackages']  = importPackages
-        data['contexts']        = contexts
+        data['context']         = context
         data['fileName']        = fileName
         if 'registerLeafInstance' in data:
             qualBlock = prj.getQualBlock(data['registerLeafInstance']['container'])
@@ -80,7 +80,7 @@ class systemVerilogGenerator:
             data['includeContext'].update(data2['includeContext'])
             data['registers'] = data2['registers']
 
-        genOut = self.renderer.renderSections(self, self.code, parser, prj, data, args)      
+        genOut = self.renderer.renderSections(self, self.code, parser, prj, data, args)
 
     def _handler_generic(self, args, prj, data):
         vars = {'prj': prj, 'block': data, 'args': args}

--- a/pysrc/textfileHelper.py
+++ b/pysrc/textfileHelper.py
@@ -109,7 +109,6 @@ class codeText:
         parser.add_argument('--context', action='append', type=str, help='Yaml file context for generation' )
         parser.add_argument('--scope', type=str, help='hierarchy scope eg top' )
         parser.add_argument('--variant', type=str, help='Block variant name' )
-        parser.add_argument('--parentModule', action='store_true', help='SystemVerilog only, identify if this is a parentModule with no user written code')
         parser.add_argument('--importPackages', default=[], nargs='+', action='append', help='SystemVerilog only, this is a list that defines all packages to import')
         parser.add_argument('--mode', type=str, default='', help='File level mode option' )
         parser.add_argument('--project', default=[], nargs='+', help='List of projects that this file belongs to if no match ignore file' )

--- a/pysrc/textfileHelper.py
+++ b/pysrc/textfileHelper.py
@@ -111,7 +111,6 @@ class codeText:
         parser.add_argument('--variant', type=str, help='Block variant name' )
         parser.add_argument('--parentModule', action='store_true', help='SystemVerilog only, identify if this is a parentModule with no user written code')
         parser.add_argument('--importPackages', default=[], nargs='+', action='append', help='SystemVerilog only, this is a list that defines all packages to import')
-        parser.add_argument('--contexts', default=[], nargs='+', help='SystemVerilog only, this is a list of contexts to declare in a package')
         parser.add_argument('--mode', type=str, default='', help='File level mode option' )
         parser.add_argument('--project', default=[], nargs='+', help='List of projects that this file belongs to if no match ignore file' )
         parser.add_argument('--hierarchy', action='store_true', help='generate in hierarchy mode' )

--- a/templates/fileGen/fileGen.py
+++ b/templates/fileGen/fileGen.py
@@ -123,9 +123,10 @@ def block_src(args, prj, data):
 def rtlModule(args, prj, data):
     out = list()
     out.append(f'//{data["fileGeneration"]["fileCopyrightStatement"]}\n\n')
-    out.append(f'// GENERATED_CODE_PARAM --block={data["block"]} --parentModule\n')
+    out.append(f'// GENERATED_CODE_PARAM --block={data["block"]}\n')
     out.append('// GENERATED_CODE_BEGIN --template=moduleInterfacesInstances\n')
     out.append('// GENERATED_CODE_END\n')
+    out.append(f'\nendmodule: {data["block"]}\n')
     return("".join(out))
 
 vlSvWrap_svTemplate = \

--- a/templates/fileGen/fileGen.py
+++ b/templates/fileGen/fileGen.py
@@ -443,7 +443,7 @@ def includeFW_src(args, prj, data):
 package_svTemplate = \
 """
 // __copyright__
-// GENERATED_CODE_PARAM --contexts=__context__
+// GENERATED_CODE_PARAM --context=__context__
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 // GENERATED_CODE_END
 """

--- a/templates/systemVerilog/apbDecodeModule.py
+++ b/templates/systemVerilog/apbDecodeModule.py
@@ -199,7 +199,7 @@ def render(args, prj, data):
 
     out += "\n"
 
-    out += f"endmodule // {data['blockName']}"
+    out += f"endmodule: {data['blockName']}"
 
     return (out)
 

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -213,7 +213,4 @@ def render(args, prj, data):
             out += f"{indent}.mem ({localMemInst}),\n"
         out += f"{indent}.clk (clk)\n);\n\n"
 
-    if data['parentModule']:
-        out += f"endmodule // {data['blockName']}"
-
     return (out)

--- a/templates/systemVerilog/package.py
+++ b/templates/systemVerilog/package.py
@@ -7,16 +7,14 @@ from pysrc.systemVerilogGeneratorHelper import importPackages
 def render(args, prj, data):
     out     = ''
     indent  = ' ' *4
-    if data['contexts'] is None:
+    if data['context'] is None:
         return out
-    packageName = prj.includeName[data['contexts'][0]] + '_package'
+    packageName = prj.includeName[data['context'][0]] + '_package'
 
     out     += f"package {packageName};\n"
-    out     += importPackages(args, prj, data['contexts'][0], data, excludeSelf=True)
+    out     += importPackages(args, prj, data['context'][0], data, excludeSelf=True)
 
     # Now put in everything at this context level
-    # print list in f string without braces; https://stackoverflow.com/a/62225685/8980882
-    out += f"//constants as defined by the scope of the following context(s): {*data['contexts'],}\n"
     # Generate constants as localparam[s]
     for unusedKey, value in data['constants'].items():
         if value['value'] > 0xFFFFFFFF:
@@ -40,7 +38,7 @@ def render(args, prj, data):
         except (ValueError, TypeError):
             width = value['width']
             if value['width'] in prj.data['constants']:
-                width = prj.data['constants'][value['width']]['constant']            
+                width = prj.data['constants'][value['width']]['constant']
         out += f"typedef enum logic[{width}-1:0] {{ {' '*value['descSpaces']}//{value['desc']}\n"
         # below loop processes enums and puts a comma after them for all in the list but the last one
         for enumData in value['enum'][:-1]:


### PR DESCRIPTION
use --context for rtl gen, same as model generation