### PR TITLE
#19 fix /etc/skel and improved options in makefile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@ export BOOST_INCLUDE=/usr/include/boost
 export TZ='US/Pacific'
 EOF
 
+# Podman hack for escape character substitution in command above
+RUN sed -i 's/\\\$/$/g' /etc/skel/.bash_custom
+
 COPY requirements.txt /tmp/a2c-requirements.txt
 RUN pip3 install -r /tmp/a2c-requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ if [ -f ~/.bash_custom ]; then
 fi
 EOF
 
-COPY <<EOF /etc/skel/.bashrc
+COPY <<EOF /etc/skel/.bash_custom
 export NVM_DIR=/usr/local/nvm
 export PATH=\${NVM_DIR}/versions/node/default/bin:\${PATH}
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,7 @@ DOCKER_WORKDIR=$(A2C_REPO_ROOT)
 DOCKER_CONTAINER=$(USER)_$(DOCKER_IMAGE)
 
 DOCKER_RUN_OPTS=
+DOCKER_USER_RUN_OPTS=
 
 # Needed by some RHEL SSH clients with podman (https://bugzilla.redhat.com/show_bug.cgi?id=1923728)
 DOCKER_RUN_OPTS += --cap-add=AUDIT_WRITE
@@ -18,6 +19,8 @@ endif
 ifdef DOCKER_RUN_DETACHED
 DOCKER_RUN_OPTS += -d
 endif
+
+DOCKER_RUN_OPTS += $(DOCKER_USER_RUN_OPTS)
 
 .PHONY: all dockerImage dockerRun
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,6 +6,16 @@ DOCKER_IMAGE=a2c-dev
 DOCKER_WORKDIR=$(A2C_REPO_ROOT)
 DOCKER_CONTAINER=$(USER)_$(DOCKER_IMAGE)
 
+DOCKER_RUN_OPTS=
+
+ifneq ($(DOCKER_SSH_PORT),'')
+DOCKER_RUN_OPTS += -p $(DOCKER_SSH_PORT):22
+endif
+
+ifdef DOCKER_RUN_DETACHED
+DOCKER_RUN_OPTS += -d
+endif
+
 .PHONY: all dockerImage dockerRun
 
 all: dockerImage dockerRun
@@ -16,5 +26,5 @@ dockerImage:
 	rm -rf $(DOCKERFILE_DIR)/requirements.txt
 
 dockerRun:
-	$(DOCKER_PRE_SH) docker run --rm -ti -v $(DOCKER_WORKDIR):/work --user $(USER) --hostname $(DOCKER_IMAGE) --name $(DOCKER_CONTAINER) --workdir "/work" --entrypoint /bin/bash $(USER)/$(DOCKER_IMAGE)
+	$(DOCKER_PRE_SH) docker run --rm -ti $(DOCKER_RUN_OPTS) -v $(DOCKER_WORKDIR):/work --user $(USER) --hostname $(DOCKER_IMAGE) --name $(DOCKER_CONTAINER) --workdir "/work" $(USER)/$(DOCKER_IMAGE)
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,9 @@ DOCKER_CONTAINER=$(USER)_$(DOCKER_IMAGE)
 
 DOCKER_RUN_OPTS=
 
+# Needed by some RHEL SSH clients with podman (https://bugzilla.redhat.com/show_bug.cgi?id=1923728)
+DOCKER_RUN_OPTS += --cap-add=AUDIT_WRITE
+
 ifneq ($(DOCKER_SSH_PORT),'')
 DOCKER_RUN_OPTS += -p $(DOCKER_SSH_PORT):22
 endif

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -29,5 +29,5 @@ dockerImage:
 	rm -rf $(DOCKERFILE_DIR)/requirements.txt
 
 dockerRun:
-	$(DOCKER_PRE_SH) docker run --rm -ti $(DOCKER_RUN_OPTS) -v $(DOCKER_WORKDIR):/work --user $(USER) --hostname $(DOCKER_IMAGE) --name $(DOCKER_CONTAINER) --workdir "/work" $(USER)/$(DOCKER_IMAGE)
+	$(DOCKER_PRE_SH) docker run --rm -ti $(DOCKER_RUN_OPTS) -v $(DOCKER_WORKDIR):/work --user $(USER) --hostname $(DOCKER_IMAGE) --name $(DOCKER_CONTAINER) --workdir '/work' $(USER)/$(DOCKER_IMAGE)
 


### PR DESCRIPTION
Run the command below to start container in detached more, with ssh port forwarding to localhost:<port>
`make dockerRun DOCKER_PRE_SH='sudo' DOCKER_SSH_PORT=<port> DOCKER_RUN_DETACHED=1`
