### PR TITLE
Feature/30 support format shim a2c dev 1 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint-build:
     runs-on: [self-hosted, linux, x64]
     container:
-      image: arch2code/a2c-dev:1.0
+      image: arch2code/a2c-dev:2.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   lint-build:
     runs-on: [self-hosted, linux, x64]
     container:
-      image: arch2code/a2c-dev:2.0
+      image: arch2code/a2c-dev:1.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/common/scmain/main.cpp
+++ b/common/scmain/main.cpp
@@ -8,7 +8,6 @@
 #include <thread>
 #include "randFactory.h"
 #include <csignal>
-#include <chrono>
 #include <sys/utsname.h>
 #include <filesystem>
 #include "instanceFactory.h"

--- a/common/systemc/Makefile
+++ b/common/systemc/Makefile
@@ -15,9 +15,9 @@ $(error LD_BOOST is not set - please set to boost library (.so) path)
 endif
 
 CXX = clang++
-CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
+CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter -DSC_CPLUSPLUS=201703L
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I/usr/local/include -Iinclude/fmt
 
 # Put all auto generated stuff to this build dir.
 BUILD_DIR = ./build

--- a/common/systemc/addressMap.h
+++ b/common/systemc/addressMap.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <memory>
 #include "logging.h"
-#include <fmt/format.h>
+#include <format>
 #include "apb_channel.h"
 #include "addressBase.h"
 #include "q_assert.h"
@@ -44,9 +44,9 @@ public:
         m_lastWriteAddress = address;
         auto it = find(address);
         if (it->m_type == addressElementType::REG) {
-            log_.logPrint([&]() { return fmt::format("Reg {} Write Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
+            log_.logPrint([&]() { return std::format("Reg {} Write Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
         } else {
-            log_.logPrint([&]() { return fmt::format("Mem {} Write Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
+            log_.logPrint([&]() { return std::format("Mem {} Write Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
         }
         it->m_ptr->cpu_write((address - it->m_address), val);
     }
@@ -54,9 +54,9 @@ public:
         auto it = find(address);
         uint32_t val = it->m_ptr->cpu_read((address - it->m_address));
         if (it->m_type == addressElementType::REG) {
-            log_.logPrint([&]() { return fmt::format("Reg {} Read Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
+            log_.logPrint([&]() { return std::format("Reg {} Read Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
         } else {
-            log_.logPrint([&]() { return fmt::format("Mem {} Read Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
+            log_.logPrint([&]() { return std::format("Mem {} Read Addr:0x{:x} Val:0x{:x}", it->m_name, address, val); });
         }
         return val;
     }
@@ -69,7 +69,7 @@ public:
                 return &it;
             }
         }
-        Q_ASSERT_CTX(false, "", fmt::format("Invalid address 0x{:x}", address));
+        Q_ASSERT_CTX(false, "", std::format("Invalid address 0x{:x}", address));
         return nullptr;
     }
 private:

--- a/common/systemc/apbBusDecode.h
+++ b/common/systemc/apbBusDecode.h
@@ -6,7 +6,7 @@
 #include "systemc.h"
 #include "apb_channel.h"
 #include "logging.h"
-#include <fmt/format.h>
+#include <format>
 #include <cmath>
 
 
@@ -33,7 +33,7 @@ public:
         }
         if (blockPorts.size() > numberOfaddressSpaces)
         {
-            Q_ASSERT_CTX(false, apbIn.name(), fmt::format("abpBusDecode::abpBusDecode: number of ports {} does not match number of address spaces {}", blockPorts.size(), numberOfaddressSpaces));
+            Q_ASSERT_CTX(false, apbIn.name(), std::format("abpBusDecode::abpBusDecode: number of ports {} does not match number of address spaces {}", blockPorts.size(), numberOfaddressSpaces));
         }
         int addressBits = 0;
         uint32_t numberOfSpaces = numberOfaddressSpaces_;
@@ -56,7 +56,7 @@ public:
             uint32_t blockAddress = (address >> addressShift) & addressMask;
             if (blockAddress >= numberOfaddressSpaces)
             {
-                Q_ASSERT_CTX(false, apbIn.name(), fmt::format("abpBusDecode::decodeThread: address {:x} out of range, block {:x}", address, blockAddress));
+                Q_ASSERT_CTX(false, apbIn.name(), std::format("abpBusDecode::decodeThread: address {:x} out of range, block {:x}", address, blockAddress));
             }
             auto port = blockPorts[blockAddress];
             if (port != nullptr)
@@ -69,7 +69,7 @@ public:
                     apbIn->complete(data);
                 }
             } else {
-                Q_ASSERT_CTX(false, apbIn.name(), fmt::format("abpBusDecode::decodeThread: address {:x} not mapped, block {:x}", address, blockAddress));
+                Q_ASSERT_CTX(false, apbIn.name(), std::format("abpBusDecode::decodeThread: address {:x} not mapped, block {:x}", address, blockAddress));
             }
         }
     }

--- a/common/systemc/apb_channel.h
+++ b/common/systemc/apb_channel.h
@@ -352,7 +352,7 @@ void apb_channel<R, D>::status(void)
     if (m_in_progress)
     {
         req_interfaceBase.log_.logPrint(
-            fmt::format("{} has data/or no ack received m_valid:{} m_ready:{} m_data_available:{} m_value_written:{} m_isWrite:{} ",
+            std::format("{} has data/or no ack received m_valid:{} m_ready:{} m_data_available:{} m_value_written:{} m_isWrite:{} ",
               name(), (uint16_t)m_valid, (uint16_t)m_ready, (uint16_t)m_data_available, (uint16_t)m_value_written, (uint16_t)m_isWrite), LOG_IMPORTANT );
         dump();
     }

--- a/common/systemc/axi_read_channel.h
+++ b/common/systemc/axi_read_channel.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <vector>
 #include "simpleQueue.h"
-#include <fmt/format.h>
+#include <format>
 #include "axiCommon.h"
 
 // sendAddr( A )
@@ -382,7 +382,7 @@ public:
     // portBase overrides
     void setMultiDriver(std::string name_, std::function<std::string(const uint64_t &value)> prt = nullptr) override
     {
-        Q_ASSERT(false, fmt::format("multiple drivers on {} axiRd interface is invalid", name_ ));
+        Q_ASSERT(false, std::format("multiple drivers on {} axiRd interface is invalid", name_ ));
     }
     std::shared_ptr<trackerBase> getTracker(void) override { return (m_data_in->getTracker());}
     virtual void setTeeBusy(bool busy) override { m_data_in->setTeeBusy(busy); }
@@ -460,7 +460,7 @@ template <class A, class D>
 inline void axi_read_channel<A, D>::manageSendDataTransaction(const axiReadRespSt<D> & data_)
 {
     if (m_transactions[data_.rid].empty()) {
-        m_data_channel.log_.logPrint(fmt::format("transaction id not valid: {}", data_.prt()));
+        m_data_channel.log_.logPrint(std::format("transaction id not valid: {}", data_.prt()));
         Q_ASSERT(false, "transaction id not valid");
     }
     m_active_write_transactions[data_.rid] = m_transactions[data_.rid].front();
@@ -471,7 +471,7 @@ template <class A, class D>
 inline void axi_read_channel<A, D>::manageReceiveDataTransaction(const axiReadRespSt<D> & data_)
 {
     if (m_transaction_pipeline[data_.rid].isEmpty()) {
-        m_data_channel.log_.logPrint(fmt::format("transaction id not valid: {}", data_.prt()));
+        m_data_channel.log_.logPrint(std::format("transaction id not valid: {}", data_.prt()));
         Q_ASSERT(false, "transaction id not valid");
     }
     m_active_read_transactions[data_.rid] = m_transaction_pipeline[data_.rid].pop();
@@ -484,7 +484,7 @@ inline void axi_read_channel<A, D>::handleSendTransactionLog(_axiIdT id)
         if (m_active_write_transactions[id].transactionStr) {
             m_logQueueData->push(*m_active_write_transactions[id].transactionStr);
         } else {
-            m_logQueueData->push(fmt::format("RTX#{:x} ",m_active_write_transactions[id].transactionNo));
+            m_logQueueData->push(std::format("RTX#{:x} ",m_active_write_transactions[id].transactionNo));
         }
     }
 }
@@ -549,7 +549,7 @@ inline void axi_read_channel<A, D>::sendAddr( const axiReadAddressSt<A>& addr_, 
         if (str) {
             m_logQueueAddr->push(*str);
         } else {
-            m_logQueueAddr->push(fmt::format("RTX#{:x} ",transactionNo));
+            m_logQueueAddr->push(std::format("RTX#{:x} ",transactionNo));
         }
     }
     m_transactions[addr_.arid].emplace(addr_.arid, addr_.arlen, addr_.arsize, transactionNo++, std::move(str));

--- a/common/systemc/axi_write_channel.h
+++ b/common/systemc/axi_write_channel.h
@@ -17,7 +17,7 @@
 #include <memory>
 #include <vector>
 #include <queue>
-#include <fmt/format.h>
+#include <format>
 #include "simpleQueue.h"
 #include "axiCommon.h"
 
@@ -478,7 +478,7 @@ public:
     // portBase overrides
     void setMultiDriver(std::string name_, std::function<std::string(const uint64_t &value)> prt = nullptr) override
     {
-        Q_ASSERT(false, fmt::format("multiple drivers on {} axiWr interface is invalid", name_ ));
+        Q_ASSERT(false, std::format("multiple drivers on {} axiWr interface is invalid", name_ ));
     }
     std::shared_ptr<trackerBase> getTracker(void) override { return (m_data_in->getTracker());}
     virtual void setTeeBusy(bool busy) override { m_data_in->setTeeBusy(busy); }
@@ -589,7 +589,7 @@ inline void axi_write_channel<A, D, S>::handleSendTransactionLog(void)
         if (m_current_send_data_transaction.transactionStr) {
             m_logQueueData->push(*m_current_send_data_transaction.transactionStr);
         } else {
-            m_logQueueData->push(fmt::format("WTX#{:x} ",m_current_send_data_transaction.transactionNo));
+            m_logQueueData->push(std::format("WTX#{:x} ",m_current_send_data_transaction.transactionNo));
         }
     }
 
@@ -598,7 +598,7 @@ template <class A, class D, class S>
 inline void axi_write_channel<A, D, S>::manageSendRespTransaction(const axiWriteRespSt & resp_)
 {
     if (m_resp_transactions[resp_.bid].empty()) {
-        m_resp_channel.log_.logPrint(fmt::format("transaction id not valid: {}", resp_.prt()));
+        m_resp_channel.log_.logPrint(std::format("transaction id not valid: {}", resp_.prt()));
         Q_ASSERT(false, "transaction id not valid");
     }
     m_current_send_resp_transaction = m_resp_transactions[resp_.bid].front();
@@ -611,7 +611,7 @@ inline void axi_write_channel<A, D, S>::handleSendRespTransactionLog(void)
         if (m_current_send_resp_transaction.transactionStr) {
             m_logQueueResp->push(*m_current_send_resp_transaction.transactionStr);
         } else {
-            m_logQueueResp->push(fmt::format("WTX#{:x} ",m_current_send_resp_transaction.transactionNo));
+            m_logQueueResp->push(std::format("WTX#{:x} ",m_current_send_resp_transaction.transactionNo));
         }
     }
 }
@@ -655,7 +655,7 @@ inline void axi_write_channel<A, D, S>::sendAddr( const axiWriteAddressSt<A>& ad
         if (str) {
             m_logQueueAddr->push(*str);
         } else {
-            m_logQueueAddr->push(fmt::format("WTX#{:x} ",txn));
+            m_logQueueAddr->push(std::format("WTX#{:x} ",txn));
         }
     }
     if (m_sender_cycle_transaction && !m_receiver_cycle_transaction) {

--- a/common/systemc/encoderBase.h
+++ b/common/systemc/encoderBase.h
@@ -2,7 +2,7 @@
 #define ENCODERBASE_H
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
 #include "logging.h"
-#include <fmt/format.h>
+#include <format>
 #include <tuple>
 #include "q_assert.h"
 
@@ -32,7 +32,7 @@ public:
          {}
     ENCODEDTYPE encode(uint64_t tag, ENUMTYPE tagType)
     {
-        Q_ASSERT_CTX(tag <= encodeInfo[tagType].max, getName(tagType), fmt::format("Tag out of range tag=0x{:x}", tag));
+        Q_ASSERT_CTX(tag <= encodeInfo[tagType].max, getName(tagType), std::format("Tag out of range tag=0x{:x}", tag));
         return( encodeInfo[tagType].encodingValue | tag );
     }
     std::tuple<uint64_t, ENUMTYPE> decode(ENCODEDTYPE encodedTag)
@@ -48,7 +48,7 @@ public:
             }
             type++;
         }
-        Q_ASSERT_CTX(false, "", fmt::format("Tag out of range tag=0x{:x}", encodedTag));
+        Q_ASSERT_CTX(false, "", std::format("Tag out of range tag=0x{:x}", encodedTag));
         return {0,(ENUMTYPE)0};
     }
     std::string getName(ENUMTYPE tagType) {return(encodeInfo[tagType].name);}

--- a/common/systemc/hwMemory.h
+++ b/common/systemc/hwMemory.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <memory>
-#include <fmt/format.h>
+#include <format>
 #include "addressBase.h"
 #include "timedDelay.h"
 #include "synchLock.h"
@@ -58,7 +58,7 @@ public:
         : m_mem(rows_),
             rows(rows_),
             m_name(std::string(hierarchicalName_) + "_" + std::string(memName_)),
-            m_memName(memName_), 
+            m_memName(memName_),
             m_delay(m_name),
             m_memType(memType_)
     {
@@ -159,7 +159,7 @@ public:
         return m_name;
     }
     // sets up the memory for row synchronization
-    void configureSynch(std::string synchLockNameBase, std::function<std::string(const arraySynchRecord &value)> prt) 
+    void configureSynch(std::string synchLockNameBase, std::function<std::string(const arraySynchRecord &value)> prt)
     {
         m_synch = true;
         m_rowLock = std::make_unique<synchArrayLock>(synchLockNameBase, m_memName, rows, prt);

--- a/common/systemc/include/fmt/format
+++ b/common/systemc/include/fmt/format
@@ -1,0 +1,17 @@
+#ifndef STD_FORMAT_SHIM_H
+#define STD_FORMAT_SHIM_H
+
+// This file is a shim to provide std::format functionality using the fmt library
+// std::format is not available in C++ compilers (GCC, Clang) prior to C++23
+
+#include <string>
+#include <fmt/core.h>
+
+namespace std {
+  template <class... Args>
+  inline std::string format(fmt::format_string<Args...> fmt_str, Args&&... args) {
+    return fmt::format(fmt_str, std::forward<Args>(args)...);
+  }
+}
+
+#endif  // STD_FORMAT_SHIM_H

--- a/common/systemc/instanceFactory.cpp
+++ b/common/systemc/instanceFactory.cpp
@@ -1,7 +1,7 @@
 //copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
 
 #include "q_assert.h"
-#include <fmt/format.h>
+#include <format>
 
 
 #include "instanceFactory.h"
@@ -35,7 +35,7 @@ std::shared_ptr< blockBase> instanceFactory::getInstance(std::string qualifiedNa
             return it->second;
         }
     }
-    Q_ASSERT_CTX_NODUMP(false, "", fmt::format("Unknown instance {} Check your command line option is a valid hierarchy name", qualifiedName) );
+    Q_ASSERT_CTX_NODUMP(false, "", std::format("Unknown instance {} Check your command line option is a valid hierarchy name", qualifiedName) );
     return NULL;
 
 }
@@ -117,7 +117,7 @@ std::shared_ptr< blockBase > instanceFactory::createInstance(const char * hierar
             return newBlock;
         }
     }
-    Q_ASSERT_CTX_NODUMP(false, "", fmt::format("Attempted to create an instance {} of an unregistered block type {}", blockName, blockType) );
+    Q_ASSERT_CTX_NODUMP(false, "", std::format("Attempted to create an instance {} of an unregistered block type {}", blockName, blockType) );
     return NULL;
 }
 void instanceFactory::setInstanceFactoryMode(instanceFactoryMode mode, std::string name)
@@ -203,7 +203,7 @@ uint64_t instanceFactory::getParam(const char * blockName, const std::string var
     if (it != getVariantParams().end()) {
             return it->second;
     }
-    Q_ASSERT_CTX_NODUMP(false, "", fmt::format("Attempted to get a parameter {} that does not exist in variant {}", variant, blockName) );
+    Q_ASSERT_CTX_NODUMP(false, "", std::format("Attempted to get a parameter {} that does not exist in variant {}", variant, blockName) );
     return 0;
 }
 std::string instanceFactory::dumpInstances(void)
@@ -243,12 +243,12 @@ std::string instanceFactory::getHierarchyName(const std::string name, blockBaseM
         }
         size_t pos = ret.find_last_of(".");
         if (pos == std::string::npos) {
-            Q_ASSERT_CTX_NODUMP(false, "", fmt::format("Could not find instance name {}", name) );
+            Q_ASSERT_CTX_NODUMP(false, "", std::format("Could not find instance name {}", name) );
         } else {
             ret = ret.substr(0, pos);
         }
     }
-    Q_ASSERT_CTX_NODUMP(false, "", fmt::format("Could not find instance name {}", name) );
+    Q_ASSERT_CTX_NODUMP(false, "", std::format("Could not find instance name {}", name) );
     return "";
 }
 

--- a/common/systemc/interfaceBase.h
+++ b/common/systemc/interfaceBase.h
@@ -78,8 +78,8 @@ public:
         {
             if (!tracker_->is_valid(tag))
             {
-                log_.logPrint(fmt::format("Invalid tracker tag:0x{:x} interface data:{}", tag, s), LOG_IMPORTANT);
-                Q_ASSERT_CTX(false, fmt::format("{}.{}", blockName_, module_), "Invalid tracker interface data");
+                log_.logPrint(std::format("Invalid tracker tag:0x{:x} interface data:{}", tag, s), LOG_IMPORTANT);
+                Q_ASSERT_CTX(false, std::format("{}.{}", blockName_, module_), "Invalid tracker interface data");
             }
             if (autoAlloc) {
                 tracker_->autoAlloc(tag, s);
@@ -118,7 +118,7 @@ public:
     {
         if (teeBusy_)
         {
-            log_.logPrint(fmt::format("Tee for {} has one side, waiting for other", module_  ) );
+            log_.logPrint(std::format("Tee for {} has one side, waiting for other", module_  ) );
         }
     }
     // in tandem mode if either autoalloc or autodealloc- do both to neutralize the ref counting

--- a/common/systemc/logging.cpp
+++ b/common/systemc/logging.cpp
@@ -72,7 +72,7 @@ void logging::logPrint(const std::string &fname, const std::string &block, const
             // Successfully obtained the time
             uint64_t useconds = (ts.tv_sec * 1000000LL + ts.tv_nsec / 1000LL) - startTime;
             sc_time current_time = sc_time_stamp();
-            timeStamp = fmt::format("{d} {} ",useconds, current_time.to_string() );
+            //timeStamp = std::format("{d} {} ",useconds, current_time );
         }
         std::cout << timeStamp << fname << logmsg;
     }
@@ -91,7 +91,7 @@ void logging::logPrintDirect(const std::string &logmsg)
             // Successfully obtained the time
             uint64_t useconds = (ts.tv_sec * 1000000LL + ts.tv_nsec / 1000LL) - startTime;
             sc_time current_time = sc_time_stamp();
-            std::string timeStamp = fmt::format("{} {} ", useconds, current_time.to_string() );
+            std::string timeStamp = std::format("{} {} ", useconds, current_time.to_string() );
             std::cout << timeStamp << logmsg << '\n';
         } else {
             std::cout << logmsg << '\n';
@@ -111,7 +111,7 @@ void logging::bufferDump(uint8_t *buff, int size)
     if (size < BYTES_PER_LINE) {
         for (int i=0; i<size; i++)
         {
-            std::cout << fmt::format("{:02x} ", (uint64_t)*(buff+i));
+            std::cout << std::format("{:02x} ", (uint64_t)*(buff+i));
         }
         std::cout << '\n';
         return;
@@ -140,14 +140,14 @@ void logging::bufferDump(uint8_t *buff, int size)
             }
             for(int i=0; i<byteAlignment; i++)
             {
-                s = fmt::format("{:02x}", (uint64_t)*(current)) + s;
+                s = std::format("{:02x}", (uint64_t)*(current)) + s;
                 current++;
             }
             s = " " + s;
         }
         for(int i=0; i<qWordAlignment; i++)
         {
-            s = fmt::format(" {:016x}", *(uint64_t*)current ) + s;
+            s = std::format(" {:016x}", *(uint64_t*)current ) + s;
             current +=8;
         }
         std::cout << std::setw(4) << line << ":" << s << '\n';
@@ -156,7 +156,7 @@ void logging::bufferDump(uint8_t *buff, int size)
     uint64_t * qWordBuff = (uint64_t *)current;
     for(int i=0; i<(middle/BYTES_PER_LINE); i++)
     {
-        std::cout << fmt::format("{:4d}: {:016x} {:016x} {:016x} {:016x}", line, *(qWordBuff+3), *(qWordBuff+2), *(qWordBuff+1), *(qWordBuff)) << '\n';
+        std::cout << std::format("{:4d}: {:016x} {:016x} {:016x} {:016x}", line, *(qWordBuff+3), *(qWordBuff+2), *(qWordBuff+1), *(qWordBuff)) << '\n';
         qWordBuff +=4;
         line++;
     }
@@ -167,7 +167,7 @@ void logging::bufferDump(uint8_t *buff, int size)
         int qWords = (back >> BYTES_PER_QWORD_LOG2);
         for(int i=0; i<qWords; i++)
         {
-            s = fmt::format(" {:016x}", *qWordBuff ) + s;
+            s = std::format(" {:016x}", *qWordBuff ) + s;
             qWordBuff++;
         }
         current = (uint8_t *)qWordBuff;
@@ -175,7 +175,7 @@ void logging::bufferDump(uint8_t *buff, int size)
         {
             for(int i=0; i<bytes; i++)
             {
-                s = fmt::format("{:02x}", (uint64_t)*current ) + s;
+                s = std::format("{:02x}", (uint64_t)*current ) + s;
                 current++;
             }
             for(int i=0; i<((BYTES_PER_QWORD-bytes) & BYTES_PER_QWORD_MASK); i++)
@@ -202,7 +202,7 @@ void logging::statusPrint(void)
         if ( status.second != nullptr ) {
             status.second();
         } else {
-            logDirect(fmt::format("statusPrint: {} is null, prev {}", status.first , prev), LOG_IMPORTANT);
+            logDirect(std::format("statusPrint: {} is null, prev {}", status.first , prev), LOG_IMPORTANT);
             Q_ASSERT_CTX_NODUMP(false, "", "statusPrint: null status");
         }
         prev = status.first;
@@ -217,7 +217,7 @@ void logging::queueStatusPrint(void)
         if ( status.second != nullptr ) {
             status.second();
         } else {
-            logDirect(fmt::format("queueStatusList: {} is null", status.first), LOG_IMPORTANT);
+            logDirect(std::format("queueStatusList: {} is null", status.first), LOG_IMPORTANT);
             Q_ASSERT_CTX_NODUMP(false, "", "queueStatusList: null status");
         }
     }
@@ -239,7 +239,7 @@ std::string logging::report(void)
         if ( report.second != nullptr ) {
             ret += report.second();
         } else {
-           logDirect(fmt::format("report: {} is null", report.first), LOG_IMPORTANT);
+           logDirect(std::format("report: {} is null", report.first), LOG_IMPORTANT);
            Q_ASSERT_CTX_NODUMP(false, "", "report: null status");
         }
     }
@@ -253,7 +253,7 @@ void logging::interfaceStatus(void)
         if ( status.second != nullptr ) {
             status.second();
         } else {
-           logDirect(fmt::format("interfaceStatus: {} is null", status.first), LOG_IMPORTANT);
+           logDirect(std::format("interfaceStatus: {} is null", status.first), LOG_IMPORTANT);
            Q_ASSERT_CTX_NODUMP(false, "", "interfaceStatus: null status");
         }
     }
@@ -268,7 +268,7 @@ void logging::lockStatus(void)
         if ( status.second != nullptr ) {
             status.second();
         } else {
-           logDirect(fmt::format("lockStatus: {} is null", status.first), LOG_IMPORTANT);
+           logDirect(std::format("lockStatus: {} is null", status.first), LOG_IMPORTANT);
             Q_ASSERT_CTX_NODUMP(false, "", "lockStatus: null status");
         }
     }

--- a/common/systemc/logging.cpp
+++ b/common/systemc/logging.cpp
@@ -71,7 +71,7 @@ void logging::logPrint(const std::string &fname, const std::string &block, const
             clock_gettime(CLOCK_MONOTONIC, &ts);
             // Successfully obtained the time
             uint64_t useconds = (ts.tv_sec * 1000000LL + ts.tv_nsec / 1000LL) - startTime;
-            sc_time current_time = sc_time_stamp();
+            //sc_time current_time = sc_time_stamp();
             //timeStamp = std::format("{d} {} ",useconds, current_time );
         }
         std::cout << timeStamp << fname << logmsg;

--- a/common/systemc/logging.h
+++ b/common/systemc/logging.h
@@ -11,7 +11,7 @@
 #include "q_assert.h"
 #include <iomanip>
 #include <atomic>
-#include <fmt/format.h>
+#include <format>
 
 const int unsigned MAX_DUMP_HALF_LIMIT = 5;
 

--- a/common/systemc/multiCycleFactory.cpp
+++ b/common/systemc/multiCycleFactory.cpp
@@ -3,7 +3,7 @@
 #include "pingPongBuffer.h"
 #include <cstring>
 #include "q_assert.h"
-#include <fmt/format.h>
+#include <format>
 
 std::unique_ptr<multiCycleBase> multiCycleFactory::createMultiCycle(std::string name, std::string type, int burst_size, int size, std::string trackerName)
 {
@@ -23,7 +23,7 @@ std::unique_ptr<multiCycleBase> multiCycleFactory::createMultiCycle(std::string 
         return std::make_unique<multiCyclePingPong>(name, burst_size, size);
     else
     {
-        Q_ASSERT_CTX(false, name, fmt::format("Multicycle type {} unknown", type));
+        Q_ASSERT_CTX(false, name, std::format("Multicycle type {} unknown", type));
         return nullptr;
     }
 }

--- a/common/systemc/notify_ack_channel.h
+++ b/common/systemc/notify_ack_channel.h
@@ -210,7 +210,7 @@ inline void notify_ack_channel<T>::notify(int magicValue)
 {
     // if we are reentering the write before the reader has had time to read the previous entry we need to block on the read event
     if (isLocking()) { synchLock_->lock(magicValue); }
-    Q_ASSERT(m_multi_writer==false, fmt::format("multiple threads driving {} interface, did you set multiwrite?", name() ));
+    Q_ASSERT(m_multi_writer==false, std::format("multiple threads driving {} interface, did you set multiwrite?", name() ));
     m_multi_writer = true;
     interfaceBase::delay(false);
     m_active = true;
@@ -231,7 +231,7 @@ template <class T>
 inline void notify_ack_channel<T>::notifyNonBlocking(void)
 {
     // if we are reentering the write before the reader has had time to read the previous entry we need to block on the read event
-    Q_ASSERT(m_multi_writer==false, fmt::format("multiple threads driving {} interface", name() ));
+    Q_ASSERT(m_multi_writer==false, std::format("multiple threads driving {} interface", name() ));
     m_multi_writer = true;
     interfaceBase::delay(false);
     m_active = true;
@@ -260,7 +260,7 @@ void notify_ack_channel<T>::status(void)
 {
     if (m_active && !m_done)
     {
-        log_.logPrint(fmt::format("{} notify issued but not ack", name()  ), LOG_IMPORTANT );
+        log_.logPrint(std::format("{} notify issued but not ack", name()  ), LOG_IMPORTANT );
     }
     teeStatus();
 }

--- a/common/systemc/pop_ack_channel.h
+++ b/common/systemc/pop_ack_channel.h
@@ -12,7 +12,7 @@
 #include "portBase.h"
 #include "interfaceBase.h"
 #include "synchLock.h"
-#include <fmt/format.h>
+#include <format>
 
 // pop( &A )
 // |        -------> popReceive( )
@@ -126,7 +126,7 @@ public:
     // portBase overrides
     void setMultiDriver(std::string name_, std::function<std::string(const uint64_t &value)> prt = nullptr) override
     {
-        Q_ASSERT(false, fmt::format("multiple drivers on {} pop_ack interface is invalid", name_ ));
+        Q_ASSERT(false, std::format("multiple drivers on {} pop_ack interface is invalid", name_ ));
     }
     std::shared_ptr<trackerBase> getTracker(void) override { return (tracker_);}
     virtual void setTeeBusy(bool busy) override { teeBusy_ = busy; }
@@ -273,7 +273,7 @@ template <class A>
 void pop_ack_channel<A>::status(void)
 {
     if (m_value_written == true) {
-        log_.logPrint(fmt::format("{} no ack received", name() ), LOG_IMPORTANT );
+        log_.logPrint(std::format("{} no ack received", name() ), LOG_IMPORTANT );
         dump();
     }
     teeStatus();

--- a/common/systemc/push_ack_channel.h
+++ b/common/systemc/push_ack_channel.h
@@ -316,7 +316,7 @@ void push_ack_channel<T>::status(void)
 {
     if (m_value_written == true)
     {
-        log_.logPrint(fmt::format("{} has data/or no ack received", name()  ), LOG_IMPORTANT );
+        log_.logPrint(std::format("{} has data/or no ack received", name()  ), LOG_IMPORTANT );
         dump();
     }
     teeStatus();

--- a/common/systemc/randFactory.cpp
+++ b/common/systemc/randFactory.cpp
@@ -1,3 +1,3 @@
 #include "randFactory.h"
 
-std::size_t randFactory::gSeed = 0x0;
+std::size_t randFactoryBase::gSeed = 0x0;

--- a/common/systemc/randFactory.h
+++ b/common/systemc/randFactory.h
@@ -6,10 +6,7 @@
 #include <memory>
 #include <boost/functional/hash.hpp>
 
-class randObject;
-class randUniformIntDistrObj;
-
-class randFactory {
+class randFactoryBase {
 public:
 
     static std::size_t gSeed;
@@ -18,22 +15,13 @@ public:
         gSeed = seed;
     }
 
-    static std::size_t str2hash(std::string s) {
-        boost::hash<std::string> hasher;
-        return hasher(s);
-    }
-
-    static std::unique_ptr<randUniformIntDistrObj> createUniformRandDistrObj(std::size_t hash, int min, int max) {
-        return std::make_unique<randUniformIntDistrObj>(hash, min, max);
-    }
-
 };
 
 class randObject {
 
 public:
     randObject(std::size_t hash = 0x0) {
-        m_seed = randFactory::gSeed;
+        m_seed = randFactoryBase::gSeed;
         // combine global seed and object hash value
         boost::hash_combine(m_seed, hash);
         m_gen = std::default_random_engine (m_seed);
@@ -67,6 +55,20 @@ class randUniformIntDistrObj: public randTmplDistrObj<std::uniform_int_distribut
 public:
     randUniformIntDistrObj(std::size_t hash, int min, int max) :
         randTmplDistrObj<std::uniform_int_distribution<int> >(hash, std::uniform_int_distribution<int>(min, max)){}
+
+};
+
+class randFactory: public randFactoryBase {
+public:
+
+    static std::size_t str2hash(std::string s) {
+        boost::hash<std::string> hasher;
+        return hasher(s);
+    }
+
+    static std::unique_ptr<randUniformIntDistrObj> createUniformRandDistrObj(std::size_t hash, int min, int max) {
+        return std::make_unique<randUniformIntDistrObj>(hash, min, max);
+    }
 
 };
 

--- a/common/systemc/rdy_vld_channel.h
+++ b/common/systemc/rdy_vld_channel.h
@@ -15,7 +15,7 @@
 #include "multiCycleBase.h"
 #include "pingPongBuffer.h"
 #include "synchLock.h"
-#include <fmt/format.h>
+#include <format>
 
 namespace sc_core {
 
@@ -211,7 +211,7 @@ public:
     // portBase overrides
     void setMultiDriver(std::string name_, std::function<std::string(const uint64_t &value)> prt = nullptr) override
     {
-        Q_ASSERT(false, fmt::format("multiple drivers on {} rdyVld interface is invalid", name_));
+        Q_ASSERT(false, std::format("multiple drivers on {} rdyVld interface is invalid", name_));
     }
     std::shared_ptr<trackerBase> getTracker(void) override { return (tracker_);}
     virtual void setTeeBusy(bool busy) override { teeBusy_ = busy; }
@@ -332,7 +332,7 @@ inline void rdy_vld_channel<T>::read( T& val_ )
         m_multicycle->copyReadData(tag, (uint8_t *)&val_);
         int buffer_size = m_multicycle->getReadBufferSize(tag);
         if (log_.isMatch(LOG_NORMAL)) {
-            interfaceLog( fmt::format("{} transferSize:0x{:0x}", val_.prt(isDebugLog), buffer_size) , tag);
+            interfaceLog( std::format("{} transferSize:0x{:0x}", val_.prt(isDebugLog), buffer_size) , tag);
         }
     }
     if (m_writer_waiting) {
@@ -483,11 +483,11 @@ template <class T>
 void rdy_vld_channel<T>::status(void)
 {
     if (m_ready && m_writer_waiting) {
-        log_.logPrint(fmt::format("{} has deadlock bug", name()), LOG_IMPORTANT);
+        log_.logPrint(std::format("{} has deadlock bug", name()), LOG_IMPORTANT);
     }
     int available = num_available();
     if (available > 0) {
-        log_.logPrint(fmt::format("{} has data", name()  ), LOG_IMPORTANT );
+        log_.logPrint(std::format("{} has data", name()  ), LOG_IMPORTANT );
         dump();
     }
     teeStatus();

--- a/common/systemc/req_ack_channel.h
+++ b/common/systemc/req_ack_channel.h
@@ -330,7 +330,7 @@ void req_ack_channel<R, A>::status(void)
 {
     if (m_value_written == true)
     {
-        req_interfaceBase.log_.logPrint(fmt::format("{} has data/or no ack received", name()  ), LOG_IMPORTANT );
+        req_interfaceBase.log_.logPrint(std::format("{} has data/or no ack received", name()  ), LOG_IMPORTANT );
         dump();
     }
     req_interfaceBase.teeStatus();

--- a/common/systemc/synchLock.h
+++ b/common/systemc/synchLock.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <map>
 #include <boost/lockfree/spsc_queue.hpp>
-#include <fmt/format.h>
+#include <format>
 #include "logging.h"
 #include <type_traits>
 #include "instanceFactory.h"

--- a/common/systemc/tracker.h
+++ b/common/systemc/tracker.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <string>
 #include <type_traits>
-#include <fmt/format.h>
+#include <format>
 #include "logging.h"
 #include "trackerBase.h"
 #include <map>
@@ -28,7 +28,7 @@ struct has_prt_method<T, std::void_t<
 template <class T>
 class tracker : public trackerBase
 {
-    static_assert(has_prt_method<T>::value, 
+    static_assert(has_prt_method<T>::value,
         "Type T must have a 'std::string prt(void)' method");
 public:
     // private counter use case
@@ -80,8 +80,8 @@ public:
         if (noAssert && !valid_[tag]) {
             return "{Invalid Tag}";
         }
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         uint64_t seq = sequenceNo_[tag];
         std::stringstream ss;
         if (tags_[tag] != nullptr) {
@@ -93,8 +93,8 @@ public:
     }
     std::string prt(const int tag, const std::string &s) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s ));
         uint64_t seq = sequenceNo_[tag];
         std::stringstream ss;
         if (tags_[tag] != nullptr) {
@@ -109,8 +109,8 @@ public:
     }
     std::string prt(const int tag, const std::string &s, const std::string &lastPrefix) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s ));
         uint64_t seq = sequenceNo_[tag];
         std::stringstream ss;
         if (tags_[tag] != nullptr) {
@@ -126,8 +126,8 @@ public:
     // version of prt that uses [] instead of {} to simplify parsing output
     std::string getString(const int tag) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         uint64_t seq = sequenceNo_[tag];
         std::stringstream ss;
         if (tags_[tag] != nullptr) {
@@ -139,8 +139,8 @@ public:
     }
     std::string getString(const int tag, const std::string &s) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x} [{}]", tag, s));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x} [{}]", tag, s));
         uint64_t seq = sequenceNo_[tag];
         std::stringstream ss;
         if (tags_[tag] != nullptr) {
@@ -156,15 +156,15 @@ public:
     }
     std::string getLastString(const int tag) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         return lastString_[tag];
     }
     void alloc(const int tag, std::shared_ptr<T> element, const int useCount=2)
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
         allocCount_[tag] += useCount;
-        Q_ASSERT_NODUMP(allocCount_[tag] <= 3, fmt::format("Too many allocs tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(allocCount_[tag] <= 3, std::format("Too many allocs tag 0x{:x}", tag ));
         // override the existing tracker info with the programatic one
         if (element != nullptr) {
             tags_[tag] = element;
@@ -190,8 +190,8 @@ public:
     }
     void dealloc(const int tag, const int useCount=2)
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP((allocCount_[tag]-useCount) >= 0, fmt::format("Too many deallocs tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP((allocCount_[tag]-useCount) >= 0, std::format("Too many deallocs tag 0x{:x}", tag ));
         // in case interface already deallocated the tag
         allocCount_[tag] -= useCount;
         if (allocCount_[tag] == 0)
@@ -210,20 +210,20 @@ public:
     }
     inline std::shared_ptr<T> info(const int tag)
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         return(tags_[tag]);
     }
     uint64_t getLen(const int tag) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         return (lenBackdoor_[tag]);
     }
     void setLen(const int tag, const uint64_t len) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         lenBackdoor_[tag] = len;
     }
     uint8_t * getBackdoorPtr(const int tag) override
@@ -238,8 +238,8 @@ public:
     }
     void setBackdoorPtr(const int tag, uint8_t * ptr) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         dataBackdoor_[tag] = ptr;
     }
     // same as setBackdoorPtr but without valid check for t0 initialization use cases
@@ -250,26 +250,26 @@ public:
     // api to allow configuring the backdoor buffer size different for different tags
     void initBackdoorBuffer(const int tag, uint32_t size) override
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
         internalBuffers[tag] = std::make_unique<std::vector<uint8_t>>(size, 0);
         dataBackdoor_[tag] = internalBuffers[tag]->data();
         lenBackdoor_[tag] = size;
     }
     int getSequenceNo(const int tag)
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         return(sequenceNo_[tag]);
     }
     void dump(void) override
     {
-        logDirect(fmt::format("Tracker: {} has {} tags allocated", name_, count_), LOG_IMPORTANT);
+        logDirect(std::format("Tracker: {} has {} tags allocated", name_, count_), LOG_IMPORTANT);
         if (!saveLastString_) {
             for (int i=0; i<size_; i++)
             {
                 if (valid_[i])
                 {
-                    logDirect(fmt::format("{} dump:0x{:x} {}", name_, i, prt(i)), LOG_IMPORTANT);
+                    logDirect(std::format("{} dump:0x{:x} {}", name_, i, prt(i)), LOG_IMPORTANT);
                 }
             }
         } else {
@@ -277,7 +277,7 @@ public:
             {
                 if (valid_[i])
                 {
-                    logDirect(fmt::format("{} dump:0x{:x} {}", name_, i, lastString_[i]), LOG_IMPORTANT);
+                    logDirect(std::format("{} dump:0x{:x} {}", name_, i, lastString_[i]), LOG_IMPORTANT);
                 }
             }
         }
@@ -292,8 +292,8 @@ public:
     }
     std::shared_ptr<T> getTagRef(const int tag)
     {
-        Q_ASSERT_NODUMP(tag < size_, fmt::format("Attempted to use out of range tag 0x{:x}", tag ));
-        Q_ASSERT_NODUMP(valid_[tag], fmt::format("Attempted to use unallocated tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(tag < size_, std::format("Attempted to use out of range tag 0x{:x}", tag ));
+        Q_ASSERT_NODUMP(valid_[tag], std::format("Attempted to use unallocated tag 0x{:x}", tag ));
         return tags_[tag];
     }
 

--- a/common/systemc/workerThread.cpp
+++ b/common/systemc/workerThread.cpp
@@ -5,7 +5,7 @@
 #include "logging.h"
 #include "workerThread.h"
 #include "endOfTest.h"
-#include <fmt/format.h>
+#include <format>
 #include "simController.h"
 
 //#define EVENTDEBUG
@@ -44,7 +44,7 @@ void workerEvent::wait(const char *why)
 workerThread::workerThread(uint64_t threadNumber_, std::shared_ptr<workerEvent> threadEvent_, std::string name_) :
         threadEvent(threadEvent_),
         threadNumber(threadNumber_),
-        log_(fmt::format("workerThread{}", threadNumber_)),
+        log_(std::format("workerThread{}", threadNumber_)),
         name(name_)
         {}
 
@@ -53,13 +53,13 @@ void workerThread::main(void)
 {
     endOfTestState &eot = endOfTestState::GetInstance();
     for(auto & worker : workers ) {
-        log_.logPrint(fmt::format("Thread {} {} hosting {} task ", threadNumber, name, worker->getName() ));
+        log_.logPrint(std::format("Thread {} {} hosting {} task ", threadNumber, name, worker->getName() ));
         worker->startupPreSimInit(); // perform any pre simulation init
     }
-    simController::advanceStartupPhase(fmt::format("Thread {} presim ", threadNumber));
+    simController::advanceStartupPhase(std::format("Thread {} presim ", threadNumber));
 
     while (simController::getStartupPhase() < STARTUP_SIMSTART) {
-        threadEvent->wait(fmt::format("Thread:{} STARTUP_SIMSTART", threadNumber).c_str());
+        threadEvent->wait(std::format("Thread:{} STARTUP_SIMSTART", threadNumber).c_str());
     }
 
     for(auto & worker : workers ) {
@@ -68,16 +68,16 @@ void workerThread::main(void)
     threadsNotIdle.resize(workers.size() + 1);
     uint64_t totalLoops = 0;
 
-    simController::advanceStartupPhase(fmt::format("Thread {} {} startupInit ", threadNumber, name));
+    simController::advanceStartupPhase(std::format("Thread {} {} startupInit ", threadNumber, name));
     while (simController::getStartupPhase() < STARTUP_DONE)
     {
-        threadEvent->wait(fmt::format("Thread:{} STARTUP_DONE", threadNumber).c_str());
+        threadEvent->wait(std::format("Thread:{} STARTUP_DONE", threadNumber).c_str());
     }
-    logging::GetInstance().registerStatus(fmt::format("Thread{}", threadNumber), [this](void){ statusPrint();});
+    logging::GetInstance().registerStatus(std::format("Thread{}", threadNumber), [this](void){ statusPrint();});
     bool running = true;
     bool didWork = false;
-    std::string idleMsg = fmt::format("ThreadIdle:{}", threadNumber);
-    std::string waitMsg = fmt::format("Thread:{}Wait", threadNumber);
+    std::string idleMsg = std::format("ThreadIdle:{}", threadNumber);
+    std::string waitMsg = std::format("Thread:{}Wait", threadNumber);
     while (running)
     {
         int threadsNotIdleCount = 0;
@@ -85,7 +85,7 @@ void workerThread::main(void)
         int id = 0;
         for(auto & worker : workers ) {
             if (worker->workAvailable()) {
-                log_.logPrint([&]() { return fmt::format("Thread {} worker {} workAvailable", threadNumber, worker->getName() ); }, LOG_DEBUG);
+                log_.logPrint([&]() { return std::format("Thread {} worker {} workAvailable", threadNumber, worker->getName() ); }, LOG_DEBUG);
                 currentThread.store(id, std::memory_order_release);
                 isIdle.store(false, std::memory_order_release);
                 worker->workCount++;
@@ -118,24 +118,24 @@ void workerThread::main(void)
     for(auto & worker : workers ) {
         worker->shutdown(); // perform any shutdown actions
     }
-    log_.logPrint(fmt::format("Thread {} {} exiting", threadNumber, name));
-    log_.logPrint(fmt::format("Thread {} total loops {}, Idle = {:f}", threadNumber, totalLoops, ((float)threadsNotIdle[0] * 100.0/totalLoops)), LOG_IMPORTANT);
+    log_.logPrint(std::format("Thread {} {} exiting", threadNumber, name));
+    log_.logPrint(std::format("Thread {} total loops {}, Idle = {:f}", threadNumber, totalLoops, ((float)threadsNotIdle[0] * 100.0/totalLoops)), LOG_IMPORTANT);
     for(uint64_t i = 1; i <= workers.size(); i++) {
-        log_.logPrint(fmt::format("Contention {} thread: {:f}", i, ((float)threadsNotIdle[i] * 100/totalLoops)), LOG_IMPORTANT);
+        log_.logPrint(std::format("Contention {} thread: {:f}", i, ((float)threadsNotIdle[i] * 100/totalLoops)), LOG_IMPORTANT);
     }
     for(uint64_t i = 0; i < workers.size(); i++) {
-        log_.logPrint(fmt::format("Thread {} {} work = {:f} idle = {:f}", threadNumber, workers[i]->getName(), ((float)workers[i]->workCount * 100.0/totalLoops), ((float)workers[i]->idleCount * 100.0/totalLoops)), LOG_IMPORTANT);
+        log_.logPrint(std::format("Thread {} {} work = {:f} idle = {:f}", threadNumber, workers[i]->getName(), ((float)workers[i]->workCount * 100.0/totalLoops), ((float)workers[i]->idleCount * 100.0/totalLoops)), LOG_IMPORTANT);
     }
 }
 
 void workerThread::statusPrint(void)
 {
-    log_.logPrint(fmt::format("Thread {} status", threadNumber), LOG_IMPORTANT);
+    log_.logPrint(std::format("Thread {} status", threadNumber), LOG_IMPORTANT);
 
     if (isIdle.load(std::memory_order_acquire))
     {
-        log_.logPrint(fmt::format("Thread {} is idle", threadNumber), LOG_IMPORTANT);
+        log_.logPrint(std::format("Thread {} is idle", threadNumber), LOG_IMPORTANT);
     } else {
-        log_.logPrint(fmt::format("Thread {} is in {}", threadNumber, workers[currentThread.load(std::memory_order_acquire)]->getName()), LOG_IMPORTANT);
+        log_.logPrint(std::format("Thread {} is in {}", threadNumber, workers[currentThread.load(std::memory_order_acquire)]->getName()), LOG_IMPORTANT);
     }
 }

--- a/common/systemc/workerThread.h
+++ b/common/systemc/workerThread.h
@@ -5,7 +5,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-#include <fmt/format.h>
+#include <format>
 #include <map>
 #include "systemc.h"
 // copyright QiStor 2022
@@ -19,7 +19,7 @@ public:
     workerEvent(std::string name_, bool isSystemCThread_) :
         isSystemCThread(isSystemCThread_),
         name(name_),
-        log_(fmt::format("workerEvent{}", name_))
+        log_(std::format("workerEvent{}", name_))
         {}
     void notify(const char *why);
     void wait(const char *why);

--- a/examples/apbDecode/model/Makefile
+++ b/examples/apbDecode/model/Makefile
@@ -7,7 +7,7 @@ DOT_DB_FILE = ../.$(PROJECTNAME).db
 $(DOT_DB_FILE):
 	make -C ../arch
 
-db: $(DOT_DB_FILE) 
+db: $(DOT_DB_FILE)
 
 ifndef SYSTEMC_INCLUDE
 $(error SYSTEMC_INCLUDE is not set - please set to systemc-2.3.4 install directory)
@@ -25,7 +25,7 @@ endif
 CXX = clang++
 CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include -I$(REPO_ROOT)/common/systemc/include/fmt
 # Final binary
 BIN = $(PROJECTNAME)
 # Put all auto generated stuff to this build dir.
@@ -38,7 +38,7 @@ HPP = $(wildcard *.h) $(wildcard ../includes/*.h )
 .DEFAULT_GOAL = $(BUILD_DIR)/$(BIN)
 .PHONY : gen db common run
 
-GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +) 
+GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +)
 #$(info  Genfiles $(GEN_FILES) )
 # All .o files go to build dir.
 OBJ = $(CPP:%.cpp=$(BUILD_DIR)/%.o)
@@ -86,5 +86,6 @@ $(BUILD_DIR)/%.o : %.cpp $(DOT_DB_FILE) $(GEN_FILES)
 .PHONY : clean
 clean :
     # This should remove all generated files.
+	$(MAKE) -C $(REPO_ROOT)/common/systemc clean
 	$(RM) -r $(BUILD_DIR)
 	$(RM) -f $(DB_FILE) $(DOT_DB_FILE)

--- a/examples/apbDecode/model/apbDecode.cpp
+++ b/examples/apbDecode/model/apbDecode.cpp
@@ -10,7 +10,7 @@ apbDecode::registerBlock apbDecode::registerBlock_; //register the block with th
 
 void apbDecode::routerDecode(void) //handle apb routing for register
 {
-    log_.logPrint(fmt::format("SystemC Thread:{} started", __func__));
+    log_.logPrint(std::format("SystemC Thread:{} started", __func__));
     decoder.decodeThread();
 }
 
@@ -25,7 +25,7 @@ apbDecode::apbDecode(sc_module_name blockName, const char * variant, blockBaseMo
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
     SC_THREAD(routerDecode);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }
 

--- a/examples/apbDecode/model/apbDecodeIncludes.cpp
+++ b/examples/apbDecode/model/apbDecodeIncludes.cpp
@@ -11,13 +11,13 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool aRegSt::operator == (const aRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (a == rhs.a);
     return ( ret );
     }
 std::string aRegSt::prt(bool all) const
 {
-    return (fmt::format("a:0x{:010x}",
+    return (std::format("a:0x{:010x}",
        (uint64_t) a
     ));
 }
@@ -41,14 +41,14 @@ void aRegSt::sc_unpack(sc_bv<37> packed_data)
     a = (thirtySevenBitT) packed_data.range(36, 0).to_uint64();
 }
 bool un0BRegSt::operator == (const un0BRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (fa == rhs.fa);
     ret = ret && (fb == rhs.fb);
     return ( ret );
     }
 std::string un0BRegSt::prt(bool all) const
 {
-    return (fmt::format("fa:0x{:02x} fb:0x{:04x}",
+    return (std::format("fa:0x{:02x} fb:0x{:04x}",
        (uint64_t) fa,
        (uint64_t) fb
     ));
@@ -79,7 +79,7 @@ void un0BRegSt::sc_unpack(sc_bv<24> packed_data)
     fa = (u8T) packed_data.range(23, 16).to_uint64();
 }
 bool un0ARegSt::operator == (const un0ARegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (fa == rhs.fa);
     ret = ret && (fb == rhs.fb);
     ret = ret && (fc == rhs.fc);
@@ -87,7 +87,7 @@ bool un0ARegSt::operator == (const un0ARegSt & rhs) const {
     }
 std::string un0ARegSt::prt(bool all) const
 {
-    return (fmt::format("fa:0x{:02x} fb:0x{:08x} fc:0x{:02x}",
+    return (std::format("fa:0x{:02x} fb:0x{:08x} fc:0x{:02x}",
        (uint64_t) fa,
        (uint64_t) fb,
        (uint64_t) fc
@@ -124,13 +124,13 @@ void un0ARegSt::sc_unpack(sc_bv<48> packed_data)
     fa = (u8T) packed_data.range(47, 40).to_uint64();
 }
 bool aSizeRegSt::operator == (const aSizeRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (index == rhs.index);
     return ( ret );
     }
 std::string aSizeRegSt::prt(bool all) const
 {
-    return (fmt::format("index:0x{:08x}",
+    return (std::format("index:0x{:08x}",
        (uint64_t) index
     ));
 }
@@ -154,13 +154,13 @@ void aSizeRegSt::sc_unpack(sc_bv<29> packed_data)
     index = (aSizeT) packed_data.range(28, 0).to_uint64();
 }
 bool apbAddrSt::operator == (const apbAddrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (address == rhs.address);
     return ( ret );
     }
 std::string apbAddrSt::prt(bool all) const
 {
-    return (fmt::format("address:0x{:08x}",
+    return (std::format("address:0x{:08x}",
        (uint64_t) address
     ));
 }
@@ -184,13 +184,13 @@ void apbAddrSt::sc_unpack(sc_bv<32> packed_data)
     address = (apbAddrT) packed_data.range(31, 0).to_uint64();
 }
 bool apbDataSt::operator == (const apbDataSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (data == rhs.data);
     return ( ret );
     }
 std::string apbDataSt::prt(bool all) const
 {
-    return (fmt::format("data:0x{:08x}",
+    return (std::format("data:0x{:08x}",
        (uint64_t) data
     ));
 }
@@ -214,13 +214,13 @@ void apbDataSt::sc_unpack(sc_bv<32> packed_data)
     data = (apbDataT) packed_data.range(31, 0).to_uint64();
 }
 bool aMemAddrSt::operator == (const aMemAddrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (address == rhs.address);
     return ( ret );
     }
 std::string aMemAddrSt::prt(bool all) const
 {
-    return (fmt::format("address:0x{:02x}",
+    return (std::format("address:0x{:02x}",
        (uint64_t) address
     ));
 }
@@ -244,13 +244,13 @@ void aMemAddrSt::sc_unpack(sc_bv<5> packed_data)
     address = (aAddrBitsT) packed_data.range(4, 0).to_uint64();
 }
 bool aMemSt::operator == (const aMemSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (data == rhs.data);
     return ( ret );
     }
 std::string aMemSt::prt(bool all) const
 {
-    return (fmt::format("data:0x{:016x}",
+    return (std::format("data:0x{:016x}",
        (uint64_t) data
     ));
 }
@@ -274,13 +274,13 @@ void aMemSt::sc_unpack(sc_bv<63> packed_data)
     data = (aDataBitsT) packed_data.range(62, 0).to_uint64();
 }
 bool bMemAddrSt::operator == (const bMemAddrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (address == rhs.address);
     return ( ret );
     }
 std::string bMemAddrSt::prt(bool all) const
 {
-    return (fmt::format("address:0x{:02x}",
+    return (std::format("address:0x{:02x}",
        (uint64_t) address
     ));
 }
@@ -304,7 +304,7 @@ void bMemAddrSt::sc_unpack(sc_bv<5> packed_data)
     address = (bAddrBitsT) packed_data.range(4, 0).to_uint64();
 }
 bool bMemSt::operator == (const bMemSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<3; i++) {
         ret = ret && (data[i] == rhs.data[i]);
     }
@@ -312,7 +312,7 @@ bool bMemSt::operator == (const bMemSt & rhs) const {
     }
 std::string bMemSt::prt(bool all) const
 {
-    return (fmt::format("data[0:2]: {}",
+    return (std::format("data[0:2]: {}",
        staticArrayPrt<u32T, 3>(data, all)
     ));
 }

--- a/examples/apbDecode/model/blockA.cpp
+++ b/examples/apbDecode/model/blockA.cpp
@@ -34,7 +34,7 @@ blockA::blockA(sc_module_name blockName, const char * variant, blockBaseMode bbM
     regs.addRegister( 0x210, 6, "roUn0A", &roUn0A );
     regs.addRegister( 0x218, 6, "extA", &extA );
     SC_THREAD(regHandler);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(LocalRegAccess);
 };

--- a/examples/apbDecode/model/blockB.cpp
+++ b/examples/apbDecode/model/blockB.cpp
@@ -28,6 +28,6 @@ blockB::blockB(sc_module_name blockName, const char * variant, blockBaseMode bbM
     regs.addRegister( 0x200, 3, "rwUn0B", &rwUn0B );
     regs.addRegister( 0x208, 4, "roB", &roB );
     SC_THREAD(regHandler);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 };

--- a/examples/apbDecode/model/cpu.cpp
+++ b/examples/apbDecode/model/cpu.cpp
@@ -14,7 +14,7 @@ cpu::cpu(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(registerTest);
 };

--- a/examples/apbDecode/model/someRapper.cpp
+++ b/examples/apbDecode/model/someRapper.cpp
@@ -29,7 +29,7 @@ someRapper::someRapper(sc_module_name blockName, const char * variant, blockBase
     uBlockA->apbReg(apb_uBlockA);
     uAPBDecode->apb_uBlockB(apb_uBlockB);
     uBlockB->apbReg(apb_uBlockB);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 };
 

--- a/examples/apbDecode/model/tagTrackers.cpp
+++ b/examples/apbDecode/model/tagTrackers.cpp
@@ -2,13 +2,13 @@
 #include <vector>
 #include <string>
 #include <boost/assert.hpp>
-#include <fmt/format.h>
+#include <format>
 #include "logging.h"
 #include "tagTrackers.h"
 
 std::string cmdIdInfo::prt(void)
 {
-    std::string s = fmt::format("dummy:0x{:x}", dummy );
+    std::string s = std::format("dummy:0x{:x}", dummy );
     return(s);
 }
 
@@ -20,7 +20,7 @@ std::string tagInfo::prt(void)
     std::string dump;
     if (cmdId != -1)
     {
-        s = fmt::format("Type:{} cmdId:0x{:x}", tagType, cmdId );
+        s = std::format("Type:{} cmdId:0x{:x}", tagType, cmdId );
     } else {
         s = "Type:" + tagType;
     }
@@ -30,11 +30,11 @@ std::string tagInfo::prt(void)
         {
             for(int i=0; i<shortDump; i++)
             {
-                dump = fmt::format("{} {:x}", dump, *(buff+i) );
+                dump = std::format("{} {:x}", dump, *(buff+i) );
             }
             dump = " Data:[" + dump + "]";
         } else {
-            dump = fmt::format(" Data:[{:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x}..]", *(buff), *(buff+1), *(buff+2), *(buff+3), *(buff+4), *(buff+5), *(buff+6), *(buff+7));
+            dump = std::format(" Data:[{:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x}..]", *(buff), *(buff+1), *(buff+2), *(buff+3), *(buff+4), *(buff+5), *(buff+6), *(buff+7));
         }
         s = s + dump;
     }

--- a/examples/apbDecode/model/tagTrackers.h
+++ b/examples/apbDecode/model/tagTrackers.h
@@ -3,18 +3,18 @@
 
 #include <vector>
 #include <string>
-#include <fmt/format.h>
+#include <format>
 
 
 
-class cmdIdInfo 
+class cmdIdInfo
 {
 public:
     int dummy;
     std::string prt(void);
 };
 
-class tagInfo 
+class tagInfo
 {
 public:
     tagInfo() : cmdId(-1), buff(nullptr), buffLen(0) {}

--- a/examples/apbDecode/model/top.cpp
+++ b/examples/apbDecode/model/top.cpp
@@ -3,7 +3,7 @@
 #include "instanceFactory.h"
 
 // GENERATED_CODE_PARAM --block=top
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "top.h"
 #include "cpu_base.h"
 #include "someRapper_base.h"
@@ -24,7 +24,7 @@ top::top(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
 // instance to instance connections via channel
     uCPU->apbReg(apbReg);
     uSomeRapper->apbReg(apbReg);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     //auto baseInstance = instanceFactory::createInstance("uProducer");
     //uProducer2 = (producer *) baseInstance.get();

--- a/examples/apbDecode/verif/blocks/apbDecode/Makefile
+++ b/examples/apbDecode/verif/blocks/apbDecode/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/apbDecode/verif/blocks/blockA/Makefile
+++ b/examples/apbDecode/verif/blocks/blockA/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 -include build/src/sc_main.d
 
@@ -48,6 +48,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/apbDecode/verif/blocks/blockB/Makefile
+++ b/examples/apbDecode/verif/blocks/blockB/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/apbDecode/verif/blocks/someRapper/Makefile
+++ b/examples/apbDecode/verif/blocks/someRapper/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/apbDecodeIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/axiDemo/model/Makefile
+++ b/examples/axiDemo/model/Makefile
@@ -7,7 +7,7 @@ DOT_DB_FILE = ../.$(PROJECTNAME).db
 $(DOT_DB_FILE):
 	make -C ../arch
 
-db: $(DOT_DB_FILE) 
+db: $(DOT_DB_FILE)
 
 ifndef SYSTEMC_INCLUDE
 $(error SYSTEMC_INCLUDE is not set - please set to systemc-2.3.4 install directory)
@@ -25,7 +25,7 @@ endif
 CXX = clang++
 CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include -I$(REPO_ROOT)/common/systemc/include/fmt
 # Final binary
 BIN = $(PROJECTNAME)
 # Put all auto generated stuff to this build dir.

--- a/examples/axiDemo/model/axiDemoIncludes.cpp
+++ b/examples/axiDemo/model/axiDemoIncludes.cpp
@@ -11,13 +11,13 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool axiAddrSt::operator == (const axiAddrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (addr == rhs.addr);
     return ( ret );
     }
 std::string axiAddrSt::prt(bool all) const
 {
-    return (fmt::format("addr:0x{:08x}",
+    return (std::format("addr:0x{:08x}",
        (uint64_t) addr
     ));
 }
@@ -41,13 +41,13 @@ void axiAddrSt::sc_unpack(sc_bv<32> packed_data)
     addr = (axiAddrT) packed_data.range(31, 0).to_uint64();
 }
 bool axiDataSt::operator == (const axiDataSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (data == rhs.data);
     return ( ret );
     }
 std::string axiDataSt::prt(bool all) const
 {
-    return (fmt::format("data:0x{:08x}",
+    return (std::format("data:0x{:08x}",
        (uint64_t) data
     ));
 }
@@ -71,13 +71,13 @@ void axiDataSt::sc_unpack(sc_bv<32> packed_data)
     data = (axiDataT) packed_data.range(31, 0).to_uint64();
 }
 bool axiStrobeSt::operator == (const axiStrobeSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (strobe == rhs.strobe);
     return ( ret );
     }
 std::string axiStrobeSt::prt(bool all) const
 {
-    return (fmt::format("strobe:0x{:01x}",
+    return (std::format("strobe:0x{:01x}",
        (uint64_t) strobe
     ));
 }

--- a/examples/axiDemo/model/axiStdIncludes.h
+++ b/examples/axiDemo/model/axiStdIncludes.h
@@ -5,7 +5,7 @@
 
 #include "systemc.h"
 #include <cstdint>
-#include <fmt/format.h>
+#include <format>
 #include <iostream>
 #include <iomanip>
 
@@ -13,11 +13,11 @@
 // GENERATED_CODE_BEGIN --template=headers --fileMapKey=include_hdr
 
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=constants 
+// GENERATED_CODE_BEGIN --template=includes --section=constants
 //constants
 
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=types 
+// GENERATED_CODE_BEGIN --template=includes --section=types
 // types
 typedef uint8_t _axiIdT; // [4] Type for axi ID tags. Used for ARID, RID, AWID, BID.
 typedef uint8_t _axiLenT; // [8] Exact number of transfers in a burst.
@@ -27,7 +27,7 @@ typedef uint8_t _axiQoST; // [4] QoS type for the AXI protocol
 typedef uint8_t _axiRegionT; // [4] Region type for the AXI protocol
 
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=enums 
+// GENERATED_CODE_BEGIN --template=includes --section=enums
 // enums
 enum  _axiResponseT {        //Response type for the AXI protocol
     AXIRESP_OKAY=0,          // OKAY
@@ -109,7 +109,7 @@ inline const char* _axiWrCacheT_prt( _axiWrCacheT val )
 }
 
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=structures 
+// GENERATED_CODE_BEGIN --template=structures
 
 // GENERATED_CODE_END
 #endif //AXISTDINCLUDES_H_

--- a/examples/axiDemo/model/consumer.cpp
+++ b/examples/axiDemo/model/consumer.cpp
@@ -2,7 +2,7 @@
 #include "testController.h"
 
 // GENERATED_CODE_PARAM --block=consumer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "consumer.h"
 SC_HAS_PROCESS(consumer);
 
@@ -15,7 +15,7 @@ consumer::consumer(sc_module_name blockName, const char * variant, blockBaseMode
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(inAXI0Rd);
     SC_THREAD(inAXI1Rd);
@@ -42,11 +42,11 @@ void consumer::inAXI0Rd(void)
         {
             resp[i].rresp = AXIRESP_OKAY;
             resp[i].rid = addr.arid;
-            resp[i].rdata.data = i * 0x01010101; 
+            resp[i].rdata.data = i * 0x01010101;
         }
         axiRd0->sendData(*resp, num_bursts);
     }
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 }
 // send and recieve single cycle transactions
 void consumer::inAXI1Rd(void)
@@ -69,7 +69,7 @@ void consumer::inAXI1Rd(void)
             axiRd1->sendDataCycle(resp);
         }
     }
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 }
 
 // send and recieve multicycle transactions
@@ -98,12 +98,12 @@ void consumer::inAXI0Wr(void)
             {
                 log_.logPrint("Data mismatch");
                 resp.bresp = AXIRESP_SLVERR;
-            }             
+            }
         }
         resp.bid = addr.awid;
         axiWr0->sendResp(resp);
-    }    
-    controller.test_complete(test_name);   
+    }
+    controller.test_complete(test_name);
 }
 // send multicycle transaction and recieve single cycle transaction
 void consumer::inAXI1Wr(void)
@@ -117,7 +117,7 @@ void consumer::inAXI1Wr(void)
         axiWriteAddressSt<axiAddrSt> addr;
         axiWriteDataSt<axiDataSt, axiStrobeSt> data;
         axiWriteRespSt resp;
-        axiWr1->receiveAddr(addr); 
+        axiWr1->receiveAddr(addr);
         int num_bursts = addr.awlen + 1;
         for (int i = 0; i < num_bursts; i++)
         {
@@ -135,8 +135,8 @@ void consumer::inAXI1Wr(void)
         }
         resp.bid = addr.awid;
         axiWr1->sendRespCycle(resp);
-    }    
-    controller.test_complete(test_name);   
+    }
+    controller.test_complete(test_name);
 
 }
 // send single cycle transaction and recieve multicycle transaction
@@ -169,8 +169,8 @@ void consumer::inAXI2Wr(void)
         }
         resp.bid = addr.awid;
         axiWr2->sendResp(resp);
-    }    
-    controller.test_complete(test_name);   
+    }
+    controller.test_complete(test_name);
 }
 
 // send and recieve single cycle transactions
@@ -186,7 +186,7 @@ void consumer::inAXI3Wr(void)
         axiWriteDataSt<axiDataSt, axiStrobeSt> data;
         axiWriteRespSt resp;
         resp.bresp = AXIRESP_OKAY;
-        axiWr3->receiveAddr(addr); 
+        axiWr3->receiveAddr(addr);
         int num_bursts = addr.awlen + 1;
         for (int i = 0; i < num_bursts; i++)
         {
@@ -202,7 +202,7 @@ void consumer::inAXI3Wr(void)
         }
         resp.bid = data.wid;
         axiWr3->sendRespCycle(resp);
-    }    
-    controller.test_complete(test_name);   
+    }
+    controller.test_complete(test_name);
 
 }

--- a/examples/axiDemo/model/producer.cpp
+++ b/examples/axiDemo/model/producer.cpp
@@ -2,7 +2,7 @@
 #include "testController.h"
 
 // GENERATED_CODE_PARAM --block=producer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "producer.h"
 SC_HAS_PROCESS(producer);
 
@@ -15,7 +15,7 @@ producer::producer(sc_module_name blockName, const char * variant, blockBaseMode
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(outAXI0Rd);
     SC_THREAD(outAXI1Rd);
@@ -62,10 +62,10 @@ void producer::outAXI0Rd(void)
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
-} 
- 
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
+}
+
 // send and recieve single cycle transactions
 void producer::outAXI1Rd(void)
 {
@@ -96,16 +96,16 @@ void producer::outAXI1Rd(void)
             }
             if ((i == 255 && cycleData.rlast == 0) || (i < 255 && cycleData.rlast == 1))
             {
-                log_.logPrint(fmt::format("Last set incorrectly on cycle: %i", i));
+                log_.logPrint(std::format("Last set incorrectly on cycle: %i", i));
                 Q_ASSERT(false, "last wrong");
             }
         }
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
-} 
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
+}
 // send and recieve multicycle transactions
 void producer::outAXI0Wr(void)
 {
@@ -135,8 +135,8 @@ void producer::outAXI0Wr(void)
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
 }
 void producer::outRespHandlerAXI0Wr(void)
 {
@@ -154,8 +154,8 @@ void producer::outRespHandlerAXI0Wr(void)
             Q_ASSERT(false, "Data mismatch");
         }
     }
-    controller.test_complete(test_name); 
-    log_.logPrint(fmt::format("Response Test {}", test_name ), LOG_ALWAYS);
+    controller.test_complete(test_name);
+    log_.logPrint(std::format("Response Test {}", test_name ), LOG_ALWAYS);
 }
 // send multicycle transaction and recieve single cycle transaction
 void producer::outAXI1Wr(void)
@@ -186,8 +186,8 @@ void producer::outAXI1Wr(void)
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
 }
 void producer::outRespHandlerAXI1Wr(void)
 {
@@ -206,8 +206,8 @@ void producer::outRespHandlerAXI1Wr(void)
         }
 
     }
-    controller.test_complete(test_name); 
-    log_.logPrint(fmt::format("Response Test {}", test_name ), LOG_ALWAYS);
+    controller.test_complete(test_name);
+    log_.logPrint(std::format("Response Test {}", test_name ), LOG_ALWAYS);
 }
 
 // send single cycle transaction and recieve multicycle transaction
@@ -240,8 +240,8 @@ void producer::outAXI2Wr(void)
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
 }
 void producer::outRespHandlerAXI2Wr(void)
 {
@@ -260,7 +260,7 @@ void producer::outRespHandlerAXI2Wr(void)
         }
 
     }
-    controller.test_complete(test_name); 
+    controller.test_complete(test_name);
 }
 
 // send and recieve single cycle transactions
@@ -293,8 +293,8 @@ void producer::outAXI3Wr(void)
     }
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end-start;
-    log_.logPrint(fmt::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
-    controller.test_complete(test_name);   
+    log_.logPrint(std::format("Test {} Elapsed time: {:f}", test_name, elapsed_seconds.count()), LOG_ALWAYS);
+    controller.test_complete(test_name);
 }
 void producer::outRespHandlerAXI3Wr(void)
 {
@@ -313,6 +313,6 @@ void producer::outRespHandlerAXI3Wr(void)
         }
 
     }
-    log_.logPrint(fmt::format("Response Test {}", test_name ), LOG_ALWAYS);
-    controller.test_complete(test_name); 
+    log_.logPrint(std::format("Response Test {}", test_name ), LOG_ALWAYS);
+    controller.test_complete(test_name);
 }

--- a/examples/axiDemo/model/top.cpp
+++ b/examples/axiDemo/model/top.cpp
@@ -4,7 +4,7 @@
 #include "instanceFactory.h"
 
 // GENERATED_CODE_PARAM --block=top
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "top.h"
 #include "producer_base.h"
 #include "consumer_base.h"
@@ -46,7 +46,7 @@ top::top(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
     uConsumer->axiWr2(axiWr2);
     uProducer->axiWr3(axiWr3);
     uConsumer->axiWr3(axiWr3);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
-        
+
 }

--- a/examples/axiDemo/verif/blocks/consumer/Makefile
+++ b/examples/axiDemo/verif/blocks/consumer/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/axiDemoIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/axiDemoIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/axiDemo/verif/blocks/producer/Makefile
+++ b/examples/axiDemo/verif/blocks/producer/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/axiDemoIncludes.cpp 
+CPP_SRCS = src/sc_main.cpp $(MODEL_DIR)/axiDemoIncludes.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/helloWorld/model/Makefile
+++ b/examples/helloWorld/model/Makefile
@@ -7,7 +7,7 @@ DOT_DB_FILE = ../.$(PROJECTNAME).db
 $(DOT_DB_FILE):
 	make -C ../arch
 
-db: $(DOT_DB_FILE) 
+db: $(DOT_DB_FILE)
 
 ifndef SYSTEMC_INCLUDE
 $(error SYSTEMC_INCLUDE is not set - please set to systemc-2.3.4 install directory)
@@ -25,7 +25,7 @@ endif
 CXX = clang++
 CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include -I$(REPO_ROOT)/common/systemc/include/fmt
 # Final binary
 BIN = $(PROJECTNAME)
 # Put all auto generated stuff to this build dir.

--- a/examples/helloWorld/model/consumer.cpp
+++ b/examples/helloWorld/model/consumer.cpp
@@ -2,7 +2,7 @@
 #include "testController.h"
 
 // GENERATED_CODE_PARAM --block=consumer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "consumer.h"
 SC_HAS_PROCESS(consumer);
 
@@ -15,7 +15,7 @@ consumer::consumer(sc_module_name blockName, const char * variant, blockBaseMode
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(consumerInRdyVld);
     SC_THREAD(consumerInReqAck);
@@ -42,8 +42,8 @@ void consumer::consumerInRdyVld(void)
     wait(SC_ZERO_TIME);
     test_rdy_vld->read(data);
     log_.logPrint("RV4");
-    controller.test_complete(test_name);   
-    
+    controller.test_complete(test_name);
+
 }
 void consumer::consumerInReqAck(void)
 {
@@ -71,8 +71,8 @@ void consumer::consumerInReqAck(void)
     ackData = reqData;
     test_req_ack->ack(ackData);
     log_.logPrint("RQA4");
-    controller.test_complete(test_name);   
-    
+    controller.test_complete(test_name);
+
 }
 void consumer::consumerInPushAck(void)
 {
@@ -99,8 +99,8 @@ void consumer::consumerInPushAck(void)
     log_.logPrint("VA6");
     test_push_ack->ack();
     log_.logPrint("VA7");
-    controller.test_complete(test_name);   
-    
+    controller.test_complete(test_name);
+
 }
 void consumer::consumerInPopAck(void)
 {
@@ -127,7 +127,7 @@ void consumer::consumerInPopAck(void)
     ackData.b = 0;
     test_pop_ack->ack(ackData);
     log_.logPrint("RDA4");
-    controller.test_complete(test_name);   
-    
+    controller.test_complete(test_name);
+
 }
 

--- a/examples/helloWorld/model/helloWorldTopIncludes.cpp
+++ b/examples/helloWorld/model/helloWorldTopIncludes.cpp
@@ -12,13 +12,13 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool test_st::operator == (const test_st & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (a == rhs.a);
     return ( ret );
     }
 std::string test_st::prt(bool all) const
 {
-    return (fmt::format("a:0x{:02x}",
+    return (std::format("a:0x{:02x}",
        (uint64_t) a
     ));
 }
@@ -42,13 +42,13 @@ void test_st::sc_unpack(sc_bv<8> packed_data)
     a = (byteT) packed_data.range(7, 0).to_uint64();
 }
 bool test_no_tracker_st::operator == (const test_no_tracker_st & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (a == rhs.a);
     return ( ret );
     }
 std::string test_no_tracker_st::prt(bool all) const
 {
-    return (fmt::format("a:0x{:02x}",
+    return (std::format("a:0x{:02x}",
        (uint64_t) a
     ));
 }
@@ -72,13 +72,13 @@ void test_no_tracker_st::sc_unpack(sc_bv<8> packed_data)
     a = (byteT) packed_data.range(7, 0).to_uint64();
 }
 bool data_st::operator == (const data_st & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (b == rhs.b);
     return ( ret );
     }
 std::string data_st::prt(bool all) const
 {
-    return (fmt::format("b:0x{:016x}",
+    return (std::format("b:0x{:016x}",
        (uint64_t) b
     ));
 }

--- a/examples/helloWorld/model/producer.cpp
+++ b/examples/helloWorld/model/producer.cpp
@@ -3,7 +3,7 @@
 #include "tagTrackers.h"
 
 // GENERATED_CODE_PARAM --block=producer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "producer.h"
 SC_HAS_PROCESS(producer);
 
@@ -16,7 +16,7 @@ producer::producer(sc_module_name blockName, const char * variant, blockBaseMode
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(producerOutRdyVld);
     SC_THREAD(producerOutPopAck);
@@ -47,7 +47,7 @@ void producer::producerOutRdyVld(void)
     data.b = 0;
     test_rdy_vld->write(data);
     log_.logPrint("RV5");
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 
 }
 void producer::producerOutReqAck(void)
@@ -74,7 +74,7 @@ void producer::producerOutReqAck(void)
     reqData.b = 0;
     test_req_ack->req(reqData, ackData);
     log_.logPrint("RQA5");
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 
 }
 void producer::producerOutPushAck(void)
@@ -100,7 +100,7 @@ void producer::producerOutPushAck(void)
     data.b = 0;
     test_push_ack->push(data);
     log_.logPrint("VA5");
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 }
 
 void producer::producerOutPopAck(void)
@@ -123,6 +123,6 @@ void producer::producerOutPopAck(void)
     log_.logPrint("RDA4");
     test_pop_ack->pop(ackData);
     log_.logPrint("RDA5");
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 
 }

--- a/examples/helloWorld/model/tagTrackers.cpp
+++ b/examples/helloWorld/model/tagTrackers.cpp
@@ -2,13 +2,13 @@
 #include <vector>
 #include <string>
 #include <boost/assert.hpp>
-#include <fmt/format.h>
+#include <format>
 #include "logging.h"
 #include "tagTrackers.h"
 
 std::string cmdIdInfo::prt(void)
 {
-    std::string s = fmt::format("dummy:0x{:x}", dummy );
+    std::string s = std::format("dummy:0x{:x}", dummy );
     return(s);
 }
 
@@ -20,7 +20,7 @@ std::string tagInfo::prt(void)
     std::string dump;
     if (cmdId != -1)
     {
-        s = fmt::format("Type:{} cmdId:0x{:x}", tagType, cmdId );
+        s = std::format("Type:{} cmdId:0x{:x}", tagType, cmdId );
     } else {
         s = "Type:" + tagType;
     }
@@ -30,11 +30,11 @@ std::string tagInfo::prt(void)
         {
             for(int i=0; i<shortDump; i++)
             {
-                dump = fmt::format("{} {:x}", dump, *(buff+i) );
+                dump = std::format("{} {:x}", dump, *(buff+i) );
             }
             dump = " Data:[" + dump + "]";
         } else {
-            dump = fmt::format(" Data:[{:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x}..]", *(buff), *(buff+1), *(buff+2), *(buff+3), *(buff+4), *(buff+5), *(buff+6), *(buff+7));
+            dump = std::format(" Data:[{:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x}..]", *(buff), *(buff+1), *(buff+2), *(buff+3), *(buff+4), *(buff+5), *(buff+6), *(buff+7));
         }
         s = s + dump;
     }

--- a/examples/helloWorld/model/tagTrackers.h
+++ b/examples/helloWorld/model/tagTrackers.h
@@ -3,18 +3,18 @@
 
 #include <vector>
 #include <string>
-#include <fmt/format.h>
+#include <format>
 
 
 
-class cmdIdInfo 
+class cmdIdInfo
 {
 public:
     int dummy;
     std::string prt(void);
 };
 
-class tagInfo 
+class tagInfo
 {
 public:
     tagInfo() : cmdId(-1), buff(nullptr), buffLen(0) {}

--- a/examples/helloWorld/model/top.cpp
+++ b/examples/helloWorld/model/top.cpp
@@ -4,7 +4,7 @@
 #include "instanceFactory.h"
 
 // GENERATED_CODE_PARAM --block=top
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "top.h"
 #include "producer_base.h"
 #include "consumer_base.h"
@@ -34,7 +34,7 @@ top::top(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
     uConsumer->test_push_ack(test_push_ack);
     uProducer->test_pop_ack(test_pop_ack);
     uConsumer->test_pop_ack(test_pop_ack);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     //auto baseInstance = instanceFactory::createInstance("uProducer");
     //uProducer2 = (producer *) baseInstance.get();

--- a/examples/inAndOut/systemVerilog/Makefile
+++ b/examples/inAndOut/systemVerilog/Makefile
@@ -12,7 +12,7 @@ all: $(DOT_DB_FILE)
 .PHONY: clean lint sim
 
 # && touch after the build command only touches the dot file if the previous command is succesful
-$(DOT_DB_FILE): 
+$(DOT_DB_FILE):
 	make -C ../arch
 
 package.f: $(DOT_DB_FILE)
@@ -32,11 +32,11 @@ sim: $(DOT_DB_FILE)
 	$(REPO_ROOT)/arch2code.py --db $(DB_FILE) -r -sc --instances $(LINT_INSTANCES) --file simInAndOut/inAndOutIncludes.h
 	$(REPO_ROOT)/arch2code.py --db $(DB_FILE) -r -sc --instances $(LINT_INSTANCES) --file simInAndOut/inAndOutIncludes.cpp
 	$(REPO_ROOT)/arch2code.py --db $(DB_FILE) -r -sc --instances $(LINT_INSTANCES) --file simInAndOut/inAndOut_base.h
-	verilator --Mdir $(VL_OBJ_DIR) -sc -sv --trace --trace-structs --trace-params --pins-bv 2 --no-timing --build -Wno-fatal -CFLAGS "-std=c++17 -I$(REPO_ROOT)/common/systemc -DVM_TRACE_VCD=1 -DVERILATOR" -LDFLAGS "-lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options" $(CPP_SRCS) --sv inAndOut_package.sv --sv inAndOut.sv --sv simInAndOut/inAndOut_hdl_sv_wrapper.sv --top inAndOut_hdl_sv_wrapper -y $(SV_COM) -exe -o simx
+	verilator --Mdir $(VL_OBJ_DIR) -sc -sv --trace --trace-structs --trace-params --pins-bv 2 --no-timing --build -Wno-fatal -CFLAGS "-std=c++17 -I$(REPO_ROOT)/common/systemc  -I$(REPO_ROOT)/common/systemc/include/fmt -DVM_TRACE_VCD=1 -DVERILATOR" -LDFLAGS "-lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options" $(CPP_SRCS) --sv inAndOut_package.sv --sv inAndOut.sv --sv simInAndOut/inAndOut_hdl_sv_wrapper.sv --top inAndOut_hdl_sv_wrapper -y $(SV_COM) -exe -o simx
 	$(VL_OBJ_DIR)/simx
 
 
 clean:
 	rm -f $(DOT_DB_FILE)
 	rm -f $(DB_FILE)
-	rm -rf $(VL_OBJ_DIR) waveform.vcd 
+	rm -rf $(VL_OBJ_DIR) waveform.vcd

--- a/examples/inAndOut/systemVerilog/simInAndOut/inAndOutIncludes.cpp
+++ b/examples/inAndOut/systemVerilog/simInAndOut/inAndOutIncludes.cpp
@@ -11,7 +11,7 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool aSt::operator == (const aSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<ASIZE2; i++) {
         ret = ret && (variablea[i] == rhs.variablea[i]);
     }
@@ -19,7 +19,7 @@ bool aSt::operator == (const aSt & rhs) const {
     }
 std::string aSt::prt(bool all) const
 {
-    return (fmt::format("variablea[0:1]: {}",
+    return (std::format("variablea[0:1]: {}",
        staticArrayPrt<aSizeT, ASIZE2>(variablea, all)
     ));
 }
@@ -63,13 +63,13 @@ void aSt::sc_unpack(sc_bv<2> packed_data)
     }
 }
 bool bSt::operator == (const bSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variableb == rhs.variableb);
     return ( ret );
     }
 std::string bSt::prt(bool all) const
 {
-    return (fmt::format("variableb:0x{:02x}",
+    return (std::format("variableb:0x{:02x}",
        (uint64_t) variableb
     ));
 }
@@ -93,13 +93,13 @@ void bSt::sc_unpack(sc_bv<5> packed_data)
     variableb = (bSizeT) packed_data.range(4, 0).to_uint64();
 }
 bool bBSt::operator == (const bBSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (ready == rhs.ready);
     return ( ret );
     }
 std::string bBSt::prt(bool all) const
 {
-    return (fmt::format("ready:{}",
+    return (std::format("ready:{}",
        readyT_prt( ready )
     ));
 }
@@ -127,14 +127,14 @@ void bBSt::sc_unpack(sc_bv<1> packed_data)
     ready = (readyT) packed_data.range(0, 0).to_uint64();
 }
 bool seeSt::operator == (const seeSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variablec == rhs.variablec);
     ret = ret && (variablec2 == rhs.variablec2);
     return ( ret );
     }
 std::string seeSt::prt(bool all) const
 {
-    return (fmt::format("variablec:0x{:01x} variablec2:0x{:01x}",
+    return (std::format("variablec:0x{:01x} variablec2:0x{:01x}",
        (uint64_t) variablec,
        (uint64_t) variablec2
     ));
@@ -165,14 +165,14 @@ void seeSt::sc_unpack(sc_bv<5> packed_data)
     variablec = (twoBitT) packed_data.range(4, 3).to_uint64();
 }
 bool dSt::operator == (const dSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variabled == rhs.variabled);
     ret = ret && (variabled2 == rhs.variabled2);
     return ( ret );
     }
 std::string dSt::prt(bool all) const
 {
-    return (fmt::format("variabled:0x{:01x} variabled2:0x{:01x}",
+    return (std::format("variabled:0x{:01x} variabled2:0x{:01x}",
        (uint64_t) variabled,
        (uint64_t) variabled2
     ));
@@ -203,7 +203,7 @@ void dSt::sc_unpack(sc_bv<7> packed_data)
     variabled = (threeBitT) packed_data.range(6, 4).to_uint64();
 }
 bool eNestedSt::operator == (const eNestedSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variablea == rhs.variablea);
     ret = ret && (bob == rhs.bob);
     for(int i=0; i<2; i++) {
@@ -213,7 +213,7 @@ bool eNestedSt::operator == (const eNestedSt & rhs) const {
     }
 std::string eNestedSt::prt(bool all) const
 {
-    return (fmt::format("variablea:0x{:01x} bob:<{}>{}",
+    return (std::format("variablea:0x{:01x} bob:<{}>{}",
        (uint64_t) variablea,
        bob.prt(all),
        structArrayPrt<seeSt, 2>(joe, "joe", all)
@@ -276,13 +276,13 @@ void eNestedSt::sc_unpack(sc_bv<18> packed_data)
     variablea = (aSizeT) packed_data.range(17, 17).to_uint64();
 }
 bool bSizeSt::operator == (const bSizeSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (index == rhs.index);
     return ( ret );
     }
 std::string bSizeSt::prt(bool all) const
 {
-    return (fmt::format("index:0x{:02x}",
+    return (std::format("index:0x{:02x}",
        (uint64_t) index
     ));
 }
@@ -306,13 +306,13 @@ void bSizeSt::sc_unpack(sc_bv<5> packed_data)
     index = (bSizeT) packed_data.range(4, 0).to_uint64();
 }
 bool eHeaderSt::operator == (const eHeaderSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (hdr == rhs.hdr);
     return ( ret );
     }
 std::string eHeaderSt::prt(bool all) const
 {
-    return (fmt::format("hdr:0x{:01x}",
+    return (std::format("hdr:0x{:01x}",
        (uint64_t) hdr
     ));
 }

--- a/examples/mixed/model/Makefile
+++ b/examples/mixed/model/Makefile
@@ -7,7 +7,7 @@ DOT_DB_FILE = ../.$(PROJECTNAME).db
 $(DOT_DB_FILE):
 	make -C ../arch
 
-db: $(DOT_DB_FILE) 
+db: $(DOT_DB_FILE)
 
 ifndef SYSTEMC_INCLUDE
 $(error SYSTEMC_INCLUDE is not set - please set to systemc-2.3.4 install directory)
@@ -25,7 +25,7 @@ endif
 CXX = clang++
 CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include -I$(REPO_ROOT)/common/systemc/include/fmt
 # Final binary
 BIN = $(PROJECTNAME)
 # Put all auto generated stuff to this build dir.
@@ -38,7 +38,7 @@ HPP = $(wildcard *.h) $(wildcard ../includes/*.h )
 .DEFAULT_GOAL = $(BUILD_DIR)/$(BIN)
 .PHONY : gen db common run
 
-GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +) 
+GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +)
 #$(info  Genfiles $(GEN_FILES) )
 # All .o files go to build dir.
 OBJ = $(CPP:%.cpp=$(BUILD_DIR)/%.o)

--- a/examples/mixed/model/apbDecode.cpp
+++ b/examples/mixed/model/apbDecode.cpp
@@ -9,7 +9,7 @@ apbDecode::registerBlock apbDecode::registerBlock_; //register the block with th
 
 void apbDecode::routerDecode(void) //handle apb routing for register
 {
-    log_.logPrint(fmt::format("SystemC Thread:{} started", __func__));
+    log_.logPrint(std::format("SystemC Thread:{} started", __func__));
     decoder.decodeThread();
 }
 
@@ -24,7 +24,7 @@ apbDecode::apbDecode(sc_module_name blockName, const char * variant, blockBaseMo
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
     SC_THREAD(routerDecode);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 };
 

--- a/examples/mixed/model/blockA.cpp
+++ b/examples/mixed/model/blockA.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=blockA
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "blockA.h"
 SC_HAS_PROCESS(blockA);
 
@@ -23,7 +23,7 @@ blockA::blockA(sc_module_name blockName, const char * variant, blockBaseMode bbM
     // register registers for FW access
     regs.addRegister( 0x0, 1, "roA", &roA );
     SC_THREAD(regHandler);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(startTest);
 }

--- a/examples/mixed/model/blockB.cpp
+++ b/examples/mixed/model/blockB.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=blockB
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "blockB.h"
 #include "blockD_base.h"
 #include "blockBRegs_base.h"
@@ -53,7 +53,7 @@ blockB::blockB(sc_module_name blockName, const char * variant, blockBaseMode bbM
     uThreeCs->see1(cStuffIf_uBlockF0_uThreeCs);
     uBlockF1->cStuffIf(cStuffIf_uBlockF1_uThreeCs);
     uThreeCs->see2(cStuffIf_uBlockF1_uThreeCs);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(doneTest);
 }

--- a/examples/mixed/model/blockBRegs.cpp
+++ b/examples/mixed/model/blockBRegs.cpp
@@ -24,7 +24,7 @@ blockBRegs::blockBRegs(sc_module_name blockName, const char * variant, blockBase
     regs.addRegister( 0x0, 1, "rwD", &rwD );
     regs.addRegister( 0x8, 1, "roBsize", &roBsize );
     SC_THREAD(regHandler);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 };
 

--- a/examples/mixed/model/blockC.cpp
+++ b/examples/mixed/model/blockC.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=blockC
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "blockC.h"
 SC_HAS_PROCESS(blockC);
 
@@ -15,6 +15,6 @@ blockC::blockC(sc_module_name blockName, const char * variant, blockBaseMode bbM
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }

--- a/examples/mixed/model/blockD.cpp
+++ b/examples/mixed/model/blockD.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=blockD
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "blockD.h"
 SC_HAS_PROCESS(blockD);
 
@@ -15,6 +15,6 @@ blockD::blockD(sc_module_name blockName, const char * variant, blockBaseMode bbM
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }

--- a/examples/mixed/model/blockF.cpp
+++ b/examples/mixed/model/blockF.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=blockF
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "blockF.h"
 SC_HAS_PROCESS(blockF);
 
@@ -16,6 +16,6 @@ blockF::blockF(sc_module_name blockName, const char * variant, blockBaseMode bbM
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }

--- a/examples/mixed/model/cpu.cpp
+++ b/examples/mixed/model/cpu.cpp
@@ -1,7 +1,7 @@
 // copyright the arch2code project contributors, see https://bitbucket.org/arch2code/arch2code/src/main/LICENSE
 
 // GENERATED_CODE_PARAM --block=cpu
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "cpu.h"
 SC_HAS_PROCESS(cpu);
 
@@ -15,7 +15,7 @@ cpu::cpu(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
 
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 
 

--- a/examples/mixed/model/mixedBlockCIncludes.cpp
+++ b/examples/mixed/model/mixedBlockCIncludes.cpp
@@ -11,14 +11,14 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool seeSt::operator == (const seeSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variablec == rhs.variablec);
     ret = ret && (variablec2 == rhs.variablec2);
     return ( ret );
     }
 std::string seeSt::prt(bool all) const
 {
-    return (fmt::format("variablec:0x{:01x} variablec2:0x{:01x}",
+    return (std::format("variablec:0x{:01x} variablec2:0x{:01x}",
        (uint64_t) variablec,
        (uint64_t) variablec2
     ));
@@ -49,13 +49,13 @@ void seeSt::sc_unpack(sc_bv<5> packed_data)
     variablec = (cSizeT) packed_data.range(4, 3).to_uint64();
 }
 bool cHeaderSt::operator == (const cHeaderSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (hdr == rhs.hdr);
     return ( ret );
     }
 std::string cHeaderSt::prt(bool all) const
 {
-    return (fmt::format("hdr:0x{:04x}",
+    return (std::format("hdr:0x{:04x}",
        (uint64_t) hdr
     ));
 }

--- a/examples/mixed/model/mixedIncludes.cpp
+++ b/examples/mixed/model/mixedIncludes.cpp
@@ -11,7 +11,7 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool aSt::operator == (const aSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<ASIZE2; i++) {
         ret = ret && (variablea[i] == rhs.variablea[i]);
     }
@@ -20,7 +20,7 @@ bool aSt::operator == (const aSt & rhs) const {
     }
 std::string aSt::prt(bool all) const
 {
-    return (fmt::format("variablea[0:1]: {} variablea2:0x{:01x}",
+    return (std::format("variablea[0:1]: {} variablea2:0x{:01x}",
        staticArrayPrt<aSizeT, ASIZE2>(variablea, all),
        (uint64_t) variablea2
     ));
@@ -70,13 +70,13 @@ void aSt::sc_unpack(sc_bv<4> packed_data)
     }
 }
 bool aASt::operator == (const aASt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variablea == rhs.variablea);
     return ( ret );
     }
 std::string aASt::prt(bool all) const
 {
-    return (fmt::format("variablea:0x{:01x}",
+    return (std::format("variablea:0x{:01x}",
        (uint64_t) variablea
     ));
 }
@@ -104,13 +104,13 @@ void aASt::sc_unpack(sc_bv<1> packed_data)
     variablea = (aSizeT) packed_data.range(0, 0).to_uint64();
 }
 bool aRegSt::operator == (const aRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (a == rhs.a);
     return ( ret );
     }
 std::string aRegSt::prt(bool all) const
 {
-    return (fmt::format("a:0x{:02x}",
+    return (std::format("a:0x{:02x}",
        (uint64_t) a
     ));
 }
@@ -134,13 +134,13 @@ void aRegSt::sc_unpack(sc_bv<7> packed_data)
     a = (sevenBitT) packed_data.range(6, 0).to_uint64();
 }
 bool dRegSt::operator == (const dRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (d == rhs.d);
     return ( ret );
     }
 std::string dRegSt::prt(bool all) const
 {
-    return (fmt::format("d:0x{:02x}",
+    return (std::format("d:0x{:02x}",
        (uint64_t) d
     ));
 }
@@ -164,14 +164,14 @@ void dRegSt::sc_unpack(sc_bv<7> packed_data)
     d = (sevenBitT) packed_data.range(6, 0).to_uint64();
 }
 bool dSt::operator == (const dSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variabled == rhs.variabled);
     ret = ret && (variabled2 == rhs.variabled2);
     return ( ret );
     }
 std::string dSt::prt(bool all) const
 {
-    return (fmt::format("variabled:0x{:01x} variabled2:0x{:01x}",
+    return (std::format("variabled:0x{:01x} variabled2:0x{:01x}",
        (uint64_t) variabled,
        (uint64_t) variabled2
     ));
@@ -202,7 +202,7 @@ void dSt::sc_unpack(sc_bv<7> packed_data)
     variabled = (threeBitT) packed_data.range(6, 4).to_uint64();
 }
 bool nestedSt::operator == (const nestedSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (variablea == rhs.variablea);
     ret = ret && (bob == rhs.bob);
     for(int i=0; i<2; i++) {
@@ -212,7 +212,7 @@ bool nestedSt::operator == (const nestedSt & rhs) const {
     }
 std::string nestedSt::prt(bool all) const
 {
-    return (fmt::format("variablea:0x{:01x} bob:<{}>{}",
+    return (std::format("variablea:0x{:01x} bob:<{}>{}",
        (uint64_t) variablea,
        bob.prt(all),
        structArrayPrt<seeSt, 2>(joe, "joe", all)
@@ -275,13 +275,13 @@ void nestedSt::sc_unpack(sc_bv<18> packed_data)
     variablea = (aSizeT) packed_data.range(17, 17).to_uint64();
 }
 bool bSizeRegSt::operator == (const bSizeRegSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (index == rhs.index);
     return ( ret );
     }
 std::string bSizeRegSt::prt(bool all) const
 {
-    return (fmt::format("index:0x{:01x}",
+    return (std::format("index:0x{:01x}",
        (uint64_t) index
     ));
 }
@@ -305,13 +305,13 @@ void bSizeRegSt::sc_unpack(sc_bv<4> packed_data)
     index = (bSizeT) packed_data.range(3, 0).to_uint64();
 }
 bool bSizeSt::operator == (const bSizeSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (index == rhs.index);
     return ( ret );
     }
 std::string bSizeSt::prt(bool all) const
 {
-    return (fmt::format("index:0x{:01x}",
+    return (std::format("index:0x{:01x}",
        (uint64_t) index
     ));
 }
@@ -335,13 +335,13 @@ void bSizeSt::sc_unpack(sc_bv<4> packed_data)
     index = (bSizeT) packed_data.range(3, 0).to_uint64();
 }
 bool apbAddrSt::operator == (const apbAddrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (address == rhs.address);
     return ( ret );
     }
 std::string apbAddrSt::prt(bool all) const
 {
-    return (fmt::format("address:0x{:08x}",
+    return (std::format("address:0x{:08x}",
        (uint64_t) address
     ));
 }
@@ -365,13 +365,13 @@ void apbAddrSt::sc_unpack(sc_bv<32> packed_data)
     address = (apbAddrT) packed_data.range(31, 0).to_uint64();
 }
 bool apbDataSt::operator == (const apbDataSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (data == rhs.data);
     return ( ret );
     }
 std::string apbDataSt::prt(bool all) const
 {
-    return (fmt::format("data:0x{:08x}",
+    return (std::format("data:0x{:08x}",
        (uint64_t) data
     ));
 }
@@ -395,7 +395,7 @@ void apbDataSt::sc_unpack(sc_bv<32> packed_data)
     data = (apbDataT) packed_data.range(31, 0).to_uint64();
 }
 bool cSt::operator == (const cSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<5; i++) {
         ret = ret && (sevenBitArray[i] == rhs.sevenBitArray[i]);
     }
@@ -403,7 +403,7 @@ bool cSt::operator == (const cSt & rhs) const {
     }
 std::string cSt::prt(bool all) const
 {
-    return (fmt::format("sevenBitArray[0:4]: {}",
+    return (std::format("sevenBitArray[0:4]: {}",
        staticArrayPrt<sevenBitT, 5>(sevenBitArray, all)
     ));
 }
@@ -447,7 +447,7 @@ void cSt::sc_unpack(sc_bv<35> packed_data)
     }
 }
 bool test1St::operator == (const test1St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<5; i++) {
         ret = ret && (sevenBitArray[i] == rhs.sevenBitArray[i]);
     }
@@ -458,7 +458,7 @@ bool test1St::operator == (const test1St & rhs) const {
     }
 std::string test1St::prt(bool all) const
 {
-    return (fmt::format("sevenBitArray[0:4]: {} sevenBitArray2[0:4]: {}",
+    return (std::format("sevenBitArray[0:4]: {} sevenBitArray2[0:4]: {}",
        staticArrayPrt<sevenBitT, 5>(sevenBitArray, all),
        staticArrayPrt<sevenBitT, 5>(sevenBitArray2, all)
     ));
@@ -525,7 +525,7 @@ void test1St::sc_unpack(sc_bv<70> packed_data)
     }
 }
 bool test2St::operator == (const test2St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<5; i++) {
         ret = ret && (thirtyFiveBitArray[i] == rhs.thirtyFiveBitArray[i]);
     }
@@ -533,7 +533,7 @@ bool test2St::operator == (const test2St & rhs) const {
     }
 std::string test2St::prt(bool all) const
 {
-    return (fmt::format("{}",
+    return (std::format("{}",
        structArrayPrt<cSt, 5>(thirtyFiveBitArray, "thirtyFiveBitArray", all)
     ));
 }
@@ -577,7 +577,7 @@ void test2St::sc_unpack(sc_bv<175> packed_data)
     }
 }
 bool test3St::operator == (const test3St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<5; i++) {
         ret = ret && (sevenBitArray[i] == rhs.sevenBitArray[i]);
     }
@@ -585,7 +585,7 @@ bool test3St::operator == (const test3St & rhs) const {
     }
 std::string test3St::prt(bool all) const
 {
-    return (fmt::format("{}",
+    return (std::format("{}",
        structArrayPrt<aRegSt, 5>(sevenBitArray, "sevenBitArray", all)
     ));
 }
@@ -629,13 +629,13 @@ void test3St::sc_unpack(sc_bv<35> packed_data)
     }
 }
 bool test4St::operator == (const test4St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (sevenBitArray == rhs.sevenBitArray);
     return ( ret );
     }
 std::string test4St::prt(bool all) const
 {
-    return (fmt::format("sevenBitArray:<{}>",
+    return (std::format("sevenBitArray:<{}>",
        sevenBitArray.prt(all)
     ));
 }
@@ -663,7 +663,7 @@ void test4St::sc_unpack(sc_bv<7> packed_data)
     sevenBitArray.sc_unpack(packed_data.range(6, 0));
 }
 bool test5St::operator == (const test5St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<10; i++) {
         ret = ret && (sevenBitArray[i] == rhs.sevenBitArray[i]);
     }
@@ -671,7 +671,7 @@ bool test5St::operator == (const test5St & rhs) const {
     }
 std::string test5St::prt(bool all) const
 {
-    return (fmt::format("{}",
+    return (std::format("{}",
        structArrayPrt<aRegSt, 10>(sevenBitArray, "sevenBitArray", all)
     ));
 }
@@ -715,13 +715,13 @@ void test5St::sc_unpack(sc_bv<70> packed_data)
     }
 }
 bool test6St::operator == (const test6St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (largeStruct == rhs.largeStruct);
     return ( ret );
     }
 std::string test6St::prt(bool all) const
 {
-    return (fmt::format("largeStruct:<{}>",
+    return (std::format("largeStruct:<{}>",
        largeStruct.prt(all)
     ));
 }
@@ -750,7 +750,7 @@ void test6St::sc_unpack(sc_bv<70> packed_data)
     largeStruct.sc_unpack(packed_data.range(69, 0));
 }
 bool test7St::operator == (const test7St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<5; i++) {
         ret = ret && (largeStruct[i] == rhs.largeStruct[i]);
     }
@@ -758,7 +758,7 @@ bool test7St::operator == (const test7St & rhs) const {
     }
 std::string test7St::prt(bool all) const
 {
-    return (fmt::format("{}",
+    return (std::format("{}",
        structArrayPrt<test1St, 5>(largeStruct, "largeStruct", all)
     ));
 }
@@ -802,7 +802,7 @@ void test7St::sc_unpack(sc_bv<350> packed_data)
     }
 }
 bool test8St::operator == (const test8St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<3; i++) {
         ret = ret && (words[i] == rhs.words[i]);
     }
@@ -810,7 +810,7 @@ bool test8St::operator == (const test8St & rhs) const {
     }
 std::string test8St::prt(bool all) const
 {
-    return (fmt::format("words[0:2]: {}",
+    return (std::format("words[0:2]: {}",
        staticArrayPrt<wordT, 3>(words, all)
     ));
 }
@@ -854,7 +854,7 @@ void test8St::sc_unpack(sc_bv<48> packed_data)
     }
 }
 bool test9St::operator == (const test9St & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     for(int i=0; i<4; i++) {
         ret = ret && (wordArray[i] == rhs.wordArray[i]);
     }
@@ -862,7 +862,7 @@ bool test9St::operator == (const test9St & rhs) const {
     }
 std::string test9St::prt(bool all) const
 {
-    return (fmt::format("{}",
+    return (std::format("{}",
        structArrayPrt<test8St, 4>(wordArray, "wordArray", all)
     ));
 }

--- a/examples/mixed/model/threeCs.cpp
+++ b/examples/mixed/model/threeCs.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=threeCs
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "threeCs.h"
 #include "blockC_base.h"
 SC_HAS_PROCESS(threeCs);
@@ -23,6 +23,6 @@ threeCs::threeCs(sc_module_name blockName, const char * variant, blockBaseMode b
     uBlockC0->see(see0);
     uBlockC1->see(see1);
     uBlockC2->see(see2);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }

--- a/examples/mixed/model/top.cpp
+++ b/examples/mixed/model/top.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=top
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "top.h"
 #include "blockA_base.h"
 #include "blockC_base.h"
@@ -44,10 +44,10 @@ top::top(sc_module_name blockName, const char * variant, blockBaseMode bbMode)
     uBlockB->apbReg(apb_uBlockB);
     uCPU->apbReg(apbReg);
     uAPBDecode->apbReg(apbReg);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 
     test_mixed_structs::test(); // Run the test for structures
-    log_.logPrint(fmt::format("Instance {} test completed.", this->name()), LOG_IMPORTANT );
-    
+    log_.logPrint(std::format("Instance {} test completed.", this->name()), LOG_IMPORTANT );
+
 }

--- a/examples/mixed/verif/blocks/blockA/Makefile
+++ b/examples/mixed/verif/blocks/blockA/Makefile
@@ -16,13 +16,13 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
-CPP_SRCS = src/sc_main.cpp 
+CPP_SRCS = src/sc_main.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 CPP_SRCS += $(wildcard $(MODEL_DIR)/*Includes.cpp)
 -include build/src/sc_main.d
@@ -48,6 +48,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/mixed/verif/blocks/blockF_variant0/Makefile
+++ b/examples/mixed/verif/blocks/blockF_variant0/Makefile
@@ -16,14 +16,14 @@ MODEL_DIR = $(PROJECT_ROOT)/model
 BUILDER_SC_COMMON = $(REPO_ROOT)/common/systemc
 
 CXX = clang++
-INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON)
+INCLUDES = -I$(PROJECT_ROOT)/verif/vl_wrap -I$(PROJECT_ROOT)/verif/vl_wrap/blocks -I$(PROJECT_ROOT)/verif/vl_wrap/obj_dir -I$(COMMON_DIR) -I$(MODEL_DIR) -I$(VERILATOR_ROOT)/include -I$(VERILATOR_ROOT)/include/vltstd -I$(BUILDER_SC_COMMON) -I$(BUILDER_SC_COMMON)/include/fmt
 
 CXXFLAGS = -c -std=c++17 -MMD -DVERILATOR -DVM_TRACE_VCD -DVERIF_TB $(INCLUDES)
 LDFLAGS = -L$(PROJECT_ROOT)/verif/vl_wrap -L$(SYSTEMC_LIBDIR) -lvl_s_wrap -lsystemc -latomic -lpthread -ldl -lfmt -L$(LD_BOOST) -lboost_system -lboost_program_options
 
 BUILD_DIR = ./build
 
-CPP_SRCS = src/sc_main.cpp 
+CPP_SRCS = src/sc_main.cpp
 CPP_SRCS += $(wildcard $(BUILDER_SC_COMMON)/*.cpp)
 CPP_SRCS += $(wildcard $(MODEL_DIR)/*Includes.cpp)
 -include build/src/sc_main.d
@@ -49,6 +49,6 @@ run:
 
 clean:
 	rm -rf build *.vcd
-	
+
 clean_all : clean
 	$(MAKE) -C $(PROJECT_ROOT)/verif/vl_wrap clean

--- a/examples/nested/model/Makefile
+++ b/examples/nested/model/Makefile
@@ -7,7 +7,7 @@ DOT_DB_FILE = ../.$(PROJECTNAME).db
 $(DOT_DB_FILE):
 	make -C ../arch
 
-db: $(DOT_DB_FILE) 
+db: $(DOT_DB_FILE)
 
 ifndef SYSTEMC_INCLUDE
 $(error SYSTEMC_INCLUDE is not set - please set to systemc-2.3.4 install directory)
@@ -25,7 +25,7 @@ endif
 CXX = clang++
 CXX_FLAGS = -std=c++17 -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter
 LD_FLAGS = -lboost_system -lboost_program_options -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -lsystemc -lfmt
-INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include
+INCLUDE = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I$(REPO_ROOT)/common/systemc -I../includes -I. -I/usr/local/include -I$(REPO_ROOT)/common/systemc/include/fmt
 # Final binary
 BIN = $(PROJECTNAME)
 # Put all auto generated stuff to this build dir.
@@ -38,7 +38,7 @@ HPP = $(wildcard *.h) $(wildcard ../includes/*.h )
 .DEFAULT_GOAL = $(BUILD_DIR)/$(BIN)
 .PHONY : gen db common run
 
-GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +) 
+GEN_FILES = $(shell find . ../includes \( -name '*.cpp' -or -name '*.h' \) -exec grep -E -l 'GENERATED_CODE_BEGIN' {} +)
 #$(info  Genfiles $(GEN_FILES) )
 # All .o files go to build dir.
 OBJ = $(CPP:%.cpp=$(BUILD_DIR)/%.o)

--- a/examples/nested/model/consumer.cpp
+++ b/examples/nested/model/consumer.cpp
@@ -4,7 +4,7 @@
 
 
 // GENERATED_CODE_PARAM --block=consumer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "consumer.h"
 SC_HAS_PROCESS(consumer);
 
@@ -19,7 +19,7 @@ consumer::consumer(sc_module_name blockName, const char * variant, blockBaseMode
         ,cmdTracker(std::static_pointer_cast< tracker < simpleString > >( trackerCollection::GetInstance().getTracker("cmdid") ))
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(consumerInRdyVldSizeTransactional1);
     SC_THREAD(consumerInRdyVldSizeTransactional2);
@@ -69,10 +69,10 @@ void consumer::consumerInRdyVldSizeTransactional(rdy_vld_in< testDataSt > &inPor
             // check if every byte is the same as the cmdid in the hdr
             if(data[i] != testCase)
             {
-                log_.logPrint(fmt::format("ERROR: {} {}", name_, test.prt()) );
+                log_.logPrint(std::format("ERROR: {} {}", name_, test.prt()) );
                 Q_ASSERT(false, "ERROR: consumerInRdyVldTransactional");
             }
-        } 
+        }
         testCase++;
     }
 }
@@ -101,14 +101,14 @@ void consumer::consumerInRdyVldSizeNonTransactional(void)
                 // check if every byte is the same as the cmdid in the hdr
                 if(*(((uint8_t *)&test.data) + i) != testCase)
                 {
-                    log_.logPrint(fmt::format("ERROR: {} {}", test_name, test.prt()) );
+                    log_.logPrint(std::format("ERROR: {} {}", test_name, test.prt()) );
                     Q_ASSERT(false, "ERROR: consumerInRdyVldSizeNonTransactional");
                 }
-            } 
+            }
         }
         testCase++;
     }
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 }
 
 
@@ -152,14 +152,14 @@ void consumer::consumerInRdyVldTrackerTransactional(rdy_vld_in< testDataSt > &in
             // check if every byte is the same as the cmdid in the hdr
             if(data[i] != testCase)
             {
-                log_.logPrint(fmt::format("ERROR: {} {}", name_, test.prt()) );
+                log_.logPrint(std::format("ERROR: {} {}", name_, test.prt()) );
                 Q_ASSERT(false, "ERROR: consumerInRdyVldTrackerTransactional");
             }
-        } 
+        }
         testCase++;
     }
 
-    
+
 
 }
 
@@ -187,12 +187,12 @@ void consumer::consumerInRdyVldTrackerNonTransactional(void)
                 // check if every byte is the same as the cmdid in the hdr
                 if(*(((uint8_t *)&test.data) + i) != testCase)
                 {
-                    log_.logPrint(fmt::format("ERROR: {} {}", test_name, test.prt()) );
+                    log_.logPrint(std::format("ERROR: {} {}", test_name, test.prt()) );
                     Q_ASSERT(false, "ERROR: consumerInRdyVldTrackerNonTransactional");
                 }
-            } 
+            }
         }
         testCase++;
     }
-    controller.test_complete(test_name);   
+    controller.test_complete(test_name);
 }

--- a/examples/nested/model/firstBlock.cpp
+++ b/examples/nested/model/firstBlock.cpp
@@ -4,7 +4,7 @@
 #include "testController.h"
 
 // GENERATED_CODE_PARAM --block=firstBlock
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "firstBlock.h"
 SC_HAS_PROCESS(firstBlock);
 
@@ -17,7 +17,7 @@ firstBlock::firstBlock(sc_module_name blockName, const char * variant, blockBase
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(producer);
     SC_THREAD(consumer);

--- a/examples/nested/model/lastBlock.cpp
+++ b/examples/nested/model/lastBlock.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=lastBlock
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "lastBlock.h"
 SC_HAS_PROCESS(lastBlock);
 
@@ -15,7 +15,7 @@ lastBlock::lastBlock(sc_module_name blockName, const char * variant, blockBaseMo
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(forwarder)
 }

--- a/examples/nested/model/nestedTopIncludes.cpp
+++ b/examples/nested/model/nestedTopIncludes.cpp
@@ -11,13 +11,13 @@
 // GENERATED_CODE_BEGIN --template=structures --section=cpp
 // structures
 bool test_st::operator == (const test_st & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (a == rhs.a);
     return ( ret );
     }
 std::string test_st::prt(bool all) const
 {
-    return (fmt::format("a:0x{:03x}",
+    return (std::format("a:0x{:03x}",
        (uint64_t) a
     ));
 }
@@ -41,14 +41,14 @@ void test_st::sc_unpack(sc_bv<10> packed_data)
     a = (cmdidT) packed_data.range(9, 0).to_uint64();
 }
 bool bigSt::operator == (const bigSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (b.word[ 0 ] == rhs.b.word[ 0 ]);
     ret = ret && (b.word[ 1 ] == rhs.b.word[ 1 ]);
     return ( ret );
     }
 std::string bigSt::prt(bool all) const
 {
-    return (fmt::format("b:0x{:08x}{:016x}",
+    return (std::format("b:0x{:08x}{:016x}",
        b.word[1],
        b.word[0]
     ));
@@ -78,14 +78,14 @@ void bigSt::sc_unpack(sc_bv<96> packed_data)
     b.word[1] = (uint64_t) packed_data.range(95, 64).to_uint64();
 }
 bool testDataSt::operator == (const testDataSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (data.word[ 0 ] == rhs.data.word[ 0 ]);
     ret = ret && (data.word[ 1 ] == rhs.data.word[ 1 ]);
     return ( ret );
     }
 std::string testDataSt::prt(bool all) const
 {
-    return (fmt::format("data:0x{:016x}{:016x}",
+    return (std::format("data:0x{:016x}{:016x}",
        data.word[1],
        data.word[0]
     ));
@@ -115,13 +115,13 @@ void testDataSt::sc_unpack(sc_bv<128> packed_data)
     data.word[1] = (uint64_t) packed_data.range(127, 64).to_uint64();
 }
 bool testDataHdrSt::operator == (const testDataHdrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (cmdid == rhs.cmdid);
     return ( ret );
     }
 std::string testDataHdrSt::prt(bool all) const
 {
-    return (fmt::format("cmdid:0x{:03x}",
+    return (std::format("cmdid:0x{:03x}",
        (uint64_t) cmdid
     ));
 }
@@ -145,13 +145,13 @@ void testDataHdrSt::sc_unpack(sc_bv<10> packed_data)
     cmdid = (cmdidT) packed_data.range(9, 0).to_uint64();
 }
 bool lengthHdrSt::operator == (const lengthHdrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (length == rhs.length);
     return ( ret );
     }
 std::string lengthHdrSt::prt(bool all) const
 {
-    return (fmt::format("length:0x{:04x}",
+    return (std::format("length:0x{:04x}",
        (uint64_t) length
     ));
 }
@@ -175,13 +175,13 @@ void lengthHdrSt::sc_unpack(sc_bv<16> packed_data)
     length = (lengthT) packed_data.range(15, 0).to_uint64();
 }
 bool cmdidHdrSt::operator == (const cmdidHdrSt & rhs) const {
-    bool ret = true; 
+    bool ret = true;
     ret = ret && (cmdid == rhs.cmdid);
     return ( ret );
     }
 std::string cmdidHdrSt::prt(bool all) const
 {
-    return (fmt::format("cmdid:0x{:03x}",
+    return (std::format("cmdid:0x{:03x}",
        (uint64_t) cmdid
     ));
 }

--- a/examples/nested/model/producer.cpp
+++ b/examples/nested/model/producer.cpp
@@ -4,7 +4,7 @@
 
 
 // GENERATED_CODE_PARAM --block=producer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "producer.h"
 SC_HAS_PROCESS(producer);
 
@@ -19,7 +19,7 @@ producer::producer(sc_module_name blockName, const char * variant, blockBaseMode
         ,cmdTracker(std::static_pointer_cast< tracker < simpleString > >( trackerCollection::GetInstance().getTracker("cmdid") ))
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(producerOutRdyVldSizeTransactional1);
     SC_THREAD(producerOutRdyVldSizeTransactional2);
@@ -34,7 +34,7 @@ producer::producer(sc_module_name blockName, const char * variant, blockBaseMode
     {
         // allocate space for buffer of size testSize
         buffers.push_back( std::make_shared<std::vector<uint8_t> >(testSize) );
-        cmdTracker->alloc(i, std::make_shared<simpleString>(fmt::format("Command %i Length 0x{:x}", i, testSize)), getTrackerRefCountDelta());
+        cmdTracker->alloc(i, std::make_shared<simpleString>(std::format("Command %i Length 0x{:x}", i, testSize)), getTrackerRefCountDelta());
         cmdTracker->setLen(i, testSize);
         cmdTracker->initBackdoorPtr(i, buffers[i]->data() );
         i++;
@@ -44,7 +44,7 @@ producer::producer(sc_module_name blockName, const char * variant, blockBaseMode
 
 
 
-// test case for rdyVld where size of transfer is provided via api 
+// test case for rdyVld where size of transfer is provided via api
 void producer::producerOutRdyVldSizeTransactional1(void)
 {
     std::string test_name = "src_trans_dest_trans_rv_size";
@@ -72,12 +72,12 @@ void producer::producerOutRdyVldSizeTransactional(rdy_vld_out< testDataSt > &out
     int testCase = 0;
     for(auto testSize : testSizes)
     {
-        // iterate over test data           
+        // iterate over test data
         testDataSt test;
 
         uint8_t * data = outPort->getWritePtr(); // get a pointer to the backdoor data buffer
         memset(data, testCase, testSize);
-    
+
         outPort->write(test, testSize); // passing in size to the write function to provide context in variable size case
         testCase++;
     }
@@ -104,8 +104,8 @@ void producer::producerOutRdyVldSizeNonTransactional(void)
         for(int cycle=0; cycle<num_cycles; cycle++)
         {
             src_clock_dest_trans_rv_size->writeClocked(test);
-        } 
-        testCase++;      
+        }
+        testCase++;
     }
     controller.test_complete(test_name);
 
@@ -139,12 +139,12 @@ void producer::producerOutRdyVldTrackerTransactional(rdy_vld_out< testDataSt > &
     int testCase = 0;
     for(auto testSize : testSizes)
     {
-        // iterate over test data           
+        // iterate over test data
         testDataSt test;
 
         uint8_t * data = cmdTracker->getBackdoorPtr(testCase); // get a pointer to the backdoor data buffer
         memset(data, testCase, testSize);
-    
+
         outPort->write(test, testCase); // passing in size to the write function to provide context in variable size case
         testCase++;
     }
@@ -173,8 +173,8 @@ void producer::producerOutRdyVldTrackerNonTransactional(void)
         for(int cycle=0; cycle<num_cycles; cycle++)
         {
             src_clock_dest_trans_rv_tracker->writeClocked(test);
-        } 
-        testCase++;      
+        }
+        testCase++;
     }
     controller.test_complete(test_name);
 

--- a/examples/nested/model/secondBlock.cpp
+++ b/examples/nested/model/secondBlock.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=secondBlock
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "secondBlock.h"
 #include "secondSubA_base.h"
 #include "secondSubB_base.h"
@@ -26,7 +26,7 @@ secondBlock::secondBlock(sc_module_name blockName, const char * variant, blockBa
 // instance to instance connections via channel
     uSecondSubA->test(test);
     uSecondSubB->test(test);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 
 }

--- a/examples/nested/model/secondSubA.cpp
+++ b/examples/nested/model/secondSubA.cpp
@@ -3,7 +3,7 @@
 
 
 // GENERATED_CODE_PARAM --block=secondSubA
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "secondSubA.h"
 SC_HAS_PROCESS(secondSubA);
 
@@ -16,7 +16,7 @@ secondSubA::secondSubA(sc_module_name blockName, const char * variant, blockBase
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(forwarder)
 }

--- a/examples/nested/model/secondSubB.cpp
+++ b/examples/nested/model/secondSubB.cpp
@@ -3,7 +3,7 @@
 
 
 // GENERATED_CODE_PARAM --block=secondSubB
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "secondSubB.h"
 SC_HAS_PROCESS(secondSubB);
 
@@ -16,7 +16,7 @@ secondSubB::secondSubB(sc_module_name blockName, const char * variant, blockBase
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(forwarder)
 }

--- a/examples/nested/model/subBlock.cpp
+++ b/examples/nested/model/subBlock.cpp
@@ -3,7 +3,7 @@
 
 
 // GENERATED_CODE_PARAM --block=subBlock
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "subBlock.h"
 SC_HAS_PROCESS(subBlock);
 
@@ -16,7 +16,7 @@ subBlock::subBlock(sc_module_name blockName, const char * variant, blockBaseMode
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
     SC_THREAD(forwarder)
 }

--- a/examples/nested/model/subBlockContainer.cpp
+++ b/examples/nested/model/subBlockContainer.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=subBlockContainer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "subBlockContainer.h"
 #include "subBlock_base.h"
 SC_HAS_PROCESS(subBlockContainer);
@@ -25,7 +25,7 @@ subBlockContainer::subBlockContainer(sc_module_name blockName, const char * vari
 // instance to instance connections via channel
     uSubBlock0->src(src);
     uSubBlock1->dst(src);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 }
 

--- a/examples/nested/model/testBlock.cpp
+++ b/examples/nested/model/testBlock.cpp
@@ -5,7 +5,7 @@
 
 
 // GENERATED_CODE_PARAM --block=testBlock
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "testBlock.h"
 SC_HAS_PROCESS(testBlock);
 
@@ -18,9 +18,9 @@ testBlock::testBlock(sc_module_name blockName, const char * variant, blockBaseMo
 // GENERATED_CODE_END
 // GENERATED_CODE_BEGIN --template=constructor --section=body
 {
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
-    
+
     SC_THREAD(producerLoop1);
     SC_THREAD(producerLoop2);
     SC_THREAD(consumerLoop1);

--- a/examples/nested/model/testContainer.cpp
+++ b/examples/nested/model/testContainer.cpp
@@ -2,7 +2,7 @@
 
 
 // GENERATED_CODE_PARAM --block=testContainer
-// GENERATED_CODE_BEGIN --template=constructor --section=init 
+// GENERATED_CODE_BEGIN --template=constructor --section=init
 #include "testContainer.h"
 #include "testBlock_base.h"
 #include "subBlockContainer_base.h"
@@ -81,7 +81,7 @@ testContainer::testContainer(sc_module_name blockName, const char * variant, blo
     uConsumer->src_clock_dest_trans_rv_size(src_clock_dest_trans_rv_size);
     uProducer->src_trans_dest_clock_rv_size(src_trans_dest_clock_rv_size);
     uConsumer->src_trans_dest_clock_rv_size(src_trans_dest_clock_rv_size);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
     // GENERATED_CODE_END
 
 }

--- a/examples/simple/model/pipe/pipeIncludes.h
+++ b/examples/simple/model/pipe/pipeIncludes.h
@@ -5,7 +5,7 @@
 
 #include "systemc.h"
 #include <cstdint>
-#include <fmt/format.h>
+#include <format>
 #include "tagTrackers.h"
 #include <iostream>
 #include <iomanip>
@@ -13,12 +13,12 @@
 // GENERATED_CODE_PARAM --context=pipe/pipe.yaml
 // GENERATED_CODE_BEGIN --template=headers --fileMapKey=include_hdr
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=constants 
+// GENERATED_CODE_BEGIN --template=includes --section=constants
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=types 
+// GENERATED_CODE_BEGIN --template=includes --section=types
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=enums 
+// GENERATED_CODE_BEGIN --template=includes --section=enums
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=structures 
+// GENERATED_CODE_BEGIN --template=structures
 // GENERATED_CODE_END
 #endif //PIPEINCLUDES_H_

--- a/examples/simple/model/simple/simpleIncludes.h
+++ b/examples/simple/model/simple/simpleIncludes.h
@@ -5,7 +5,7 @@
 
 #include "systemc.h"
 #include <cstdint>
-#include <fmt/format.h>
+#include <format>
 #include "tagTrackers.h"
 #include <iostream>
 #include <iomanip>
@@ -13,12 +13,12 @@
 // GENERATED_CODE_PARAM --context=simple/simple.yaml
 // GENERATED_CODE_BEGIN --template=headers --fileMapKey=include_hdr
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=constants 
+// GENERATED_CODE_BEGIN --template=includes --section=constants
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=types 
+// GENERATED_CODE_BEGIN --template=includes --section=types
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=includes --section=enums 
+// GENERATED_CODE_BEGIN --template=includes --section=enums
 // GENERATED_CODE_END
-// GENERATED_CODE_BEGIN --template=structures 
+// GENERATED_CODE_BEGIN --template=structures
 // GENERATED_CODE_END
 #endif //SIMPLEINCLUDES_H_

--- a/include/make/a2c-common.mk
+++ b/include/make/a2c-common.mk
@@ -70,6 +70,11 @@ define find_sv_source_directories
 	done)
 endef
 
+# Returns '1' when g++ is used with c++23
+define is_gcc_cxx23
+$(if $(and $(filter g++, $(CXX)), $(filter c++23, $(C_STD_VER))), true, false)
+endef
+
 #------------------------------------------------------------------------
 # Project global variables
 #------------------------------------------------------------------------

--- a/include/make/a2c-systemc.mk
+++ b/include/make/a2c-systemc.mk
@@ -36,7 +36,7 @@ endif
 # Systemc build global variables
 #------------------------------------------------------------------------
 
-CXX_FLAGS = -m64 -std=$(C_STD_VER) -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter -pthread -DBOOST_STACKTRACE_LINK
+CXX_FLAGS = -m64 -std=$(C_STD_VER) -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter -pthread -DBOOST_STACKTRACE_LINK -DSC_CPLUSPLUS=201703L
 LD_FLAGS = -lboost_system -lboost_program_options -lboost_stacktrace_basic -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -ldl -lrt -lsystemc
 CPP_INCLUDES = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I/usr/local/include
 
@@ -47,8 +47,9 @@ ifndef USE_GNU_COMPILER
 CXX_FLAGS += -fstandalone-debug
 endif
 
-ifneq ($(C_STD_VER), c++23)
-CPP_INCLUDES += -I$(A2C_ROOT)/common/systemc/fmt_shim
+# If not using g++ with c++23, use std::format shim and fmt library
+ifneq ($(strip $(call is_gcc_cxx23)), true)
+CPP_INCLUDES += -I$(A2C_ROOT)/common/systemc/include/fmt
 LD_FLAGS += -lfmt
 endif
 

--- a/include/make/a2c-systemc.mk
+++ b/include/make/a2c-systemc.mk
@@ -37,7 +37,7 @@ endif
 #------------------------------------------------------------------------
 
 CXX_FLAGS = -m64 -std=$(C_STD_VER) -g -Wfatal-errors -Wall -Wextra -Wpedantic -Wshadow -Wno-unused-variable -Wno-unused-parameter -pthread -DBOOST_STACKTRACE_LINK
-LD_FLAGS = -lboost_system -lboost_program_options -lboost_stacktrace_basic -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -ldl -lrt -lsystemc -lfmt
+LD_FLAGS = -lboost_system -lboost_program_options -lboost_stacktrace_basic -L$(LD_BOOST) -L$(SYSTEMC_LIBDIR) -ldl -lrt -lsystemc
 CPP_INCLUDES = -I$(BOOST_INCLUDE) -I$(SYSTEMC_INCLUDE) -I/usr/local/include
 
 A2C_SRC_DIRS = $(A2C_ROOT)/common/systemc $(A2C_ROOT)/common/scmain
@@ -45,6 +45,11 @@ PRJ_SRC_DIRS = $(call find_cpp_source_directories, $(REPO_ROOT)/base $(REPO_ROOT
 
 ifndef USE_GNU_COMPILER
 CXX_FLAGS += -fstandalone-debug
+endif
+
+ifneq ($(C_STD_VER), c++23)
+CPP_INCLUDES += -I$(A2C_ROOT)/common/systemc/fmt_shim
+LD_FLAGS += -lfmt
 endif
 
 # Standard optimization source files.

--- a/templates/systemc/blockRegs.py
+++ b/templates/systemc/blockRegs.py
@@ -12,7 +12,7 @@ def render(args, prj, data):
 
 def render_sc(args, prj, data):
 
-    
+
     match args.section:
         case 'header': return render_section_header(args, prj, data)
         case 'init' : return render_section_init(args, prj, data)
@@ -32,11 +32,11 @@ def get_include_deps(prj, data):
 def get_reghandler_properties(prj, data):
     reghandler = dict()
     rhd = data['addressDecode']
-    reghandler = { 
-        "port_name": rhd['registerBusInterface'], 
-        "addr_type" : rhd['registerBusStructs']['addr_t'], 
-        "data_type" : rhd['registerBusStructs']['data_t'], 
-        "addressmask" : f"(1<<({rhd['addressBits']}-1))-1" 
+    reghandler = {
+        "port_name": rhd['registerBusInterface'],
+        "addr_type" : rhd['registerBusStructs']['addr_t'],
+        "data_type" : rhd['registerBusStructs']['data_t'],
+        "addressmask" : f"(1<<({rhd['addressBits']}-1))-1"
     }
     return reghandler
 
@@ -136,5 +136,5 @@ block_regs_body_section_template = '''\
         regs.addRegister({{entry.offset}}, {{entry.size//4}}, "{{entry.port_name}}", &{{entry.name}} );
     {% endfor %}
     SC_THREAD(regHandler);
-    log_.logPrint(fmt::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
+    log_.logPrint(std::format("Instance {} initialized.", this->name()), LOG_IMPORTANT );
 '''

--- a/templates/systemc/constructor.py
+++ b/templates/systemc/constructor.py
@@ -39,7 +39,7 @@ def constructorInit(args, prj, data):
 
     if data['addressDecode']['isApbRouter']:
         out.append(f'void { className }::routerDecode(void) //handle apb routing for register\n{{\n')
-        out.append(f'    log_.logPrint(fmt::format("SystemC Thread:{{}} started", __func__));\n')
+        out.append(f'    log_.logPrint(std::format("SystemC Thread:{{}} started", __func__));\n')
         out.append(f'    decoder.decodeThread();\n}}\n\n')
 
     if data['addressDecode']['hasDecoder']:
@@ -195,7 +195,7 @@ def constructorBody(args, prj, data):
         out.append(f'    SC_THREAD(routerDecode);\n')
     if data['addressDecode']['hasDecoder']:
         out.append(f'    SC_THREAD(regHandler);\n')
-    out.append(f'    log_.logPrint(fmt::format("Instance {{}} initialized.", this->name()), LOG_IMPORTANT );\n')
+    out.append(f'    log_.logPrint(std::format("Instance {{}} initialized.", this->name()), LOG_IMPORTANT );\n')
     # take the list and return a string
     if out:
         last = out.pop()

--- a/templates/systemc/structures.py
+++ b/templates/systemc/structures.py
@@ -909,10 +909,11 @@ def fw_unpack(handle, args, vars, indent):
             else:
                 # cases include whether src or dst is >=64 bits
                 # if tmp is <= 32 bit we want to use a 64 bit temp to prevent alignment issues and cast for the unpack
-                out.append(f"{indent}{varType}::_packedSt _tmp{{0}};\n")
                 if data['bitwidth'] <= 32:
+                    out.append(f"{indent}uint64_t _tmp{{0}};\n")
                     unpackCast = f"*(({varType}::_packedSt*)&_tmp)"
                 else:
+                    out.append(f"{indent}{varType}::_packedSt _tmp{{0}};\n")
                     unpackCast = f"_tmp"
                 if (bitwidth >= 64):
                     # src is using 64 bit words so use pass by pointer

--- a/templates/systemc/structures.py
+++ b/templates/systemc/structures.py
@@ -298,7 +298,7 @@ def equalTest(handle, args, structName, vars, indent):
         out.append(f"{indent}bool {decl}{structName}::operator == (const { structName } & rhs) const {{\n")
     else:
         return out
-    out.append(f"{indent}    bool ret = true; \n")
+    out.append(f"{indent}    bool ret = true;\n")
     indent += ' '*4
     for var, vardata in vars["vars"].items():
         varName = vardata['variable']
@@ -459,7 +459,7 @@ def prtFmt(handle, args, vars, indent, prj):
             varOut.append(f'{indent}   {item[2]},\n')
     # add semicolon to the last item in the list
     varOut[-1] = varOut[-1].replace(',\n', '\n')
-    out.append(f'{indent}return (fmt::format("{fmt}",\n')
+    out.append(f'{indent}return (std::format("{fmt}",\n')
     out.extend(varOut)
     out.append(f"{indent}));\n")
     indent = indent[:-4]
@@ -901,7 +901,7 @@ def fw_unpack(handle, args, vars, indent):
             loop_current = currentPos
             # we are aligned if the current position is a multiple of the base size
             # except for the array case, unless the array case is the single element array case)
-            isAligned = ((currentPos & (baseMask)) == 0) and not (data['isArray'] and not isSingleArray) 
+            isAligned = ((currentPos & (baseMask)) == 0) and not (data['isArray'] and not isSingleArray)
             out.append(f'{indent}{{\n')
             indent += ' '*4
             if (isAligned):

--- a/templates/systemc/structures.py
+++ b/templates/systemc/structures.py
@@ -909,11 +909,10 @@ def fw_unpack(handle, args, vars, indent):
             else:
                 # cases include whether src or dst is >=64 bits
                 # if tmp is <= 32 bit we want to use a 64 bit temp to prevent alignment issues and cast for the unpack
+                out.append(f"{indent}{varType}::_packedSt _tmp{{0}};\n")
                 if data['bitwidth'] <= 32:
-                    out.append(f"{indent}uint64_t _tmp{{0}};\n")
                     unpackCast = f"*(({varType}::_packedSt*)&_tmp)"
                 else:
-                    out.append(f"{indent}{varType}::_packedSt _tmp{{0}};\n")
                     unpackCast = f"_tmp"
                 if (bitwidth >= 64):
                     # src is using 64 bit words so use pass by pointer


### PR DESCRIPTION
This PR is targeting the version of the a2c repository that is backward compatible with toolset in a2c-dev:1.0 container with c++17, while using the std::format from c++23 on top of fmt::format and fmt lib, with minimal impact on build command
