### PR TITLE
#42 prevent generator failure with omitted dst in channel name

### DIFF
--- a/examples/apbDecode/model/cpu.cpp
+++ b/examples/apbDecode/model/cpu.cpp
@@ -64,11 +64,11 @@ void cpu::memAccessTest(void)
     std::array<aMemSt, MEMORYA_WORDS>  aTableData0;
 
     // Memory blockATable0 Write sequential
-    for(int rowId=0; rowId<MEMORYA_WORDS; rowId++)
+    for(unsigned int rowId=0; rowId<MEMORYA_WORDS; rowId++)
         writeBlockATable0Mem(rowId, aTableData0_[rowId]);
 
     // Memory blockATable0 Read sequential
-    for(int rowId=0; rowId<MEMORYA_WORDS; rowId++)
+    for(unsigned int rowId=0; rowId<MEMORYA_WORDS; rowId++)
         readBlockATable0Mem(rowId, aTableData0[rowId]);
 
     // Compare data from blockATable0 array

--- a/examples/mixed/model/blockB.cpp
+++ b/examples/mixed/model/blockB.cpp
@@ -19,7 +19,7 @@ blockB::blockB(sc_module_name blockName, const char * variant, blockBaseMode bbM
         ,cStuffIf_uBlockD_uThreeCs("threeCs_cStuffIf_uBlockD_uThreeCs", "blockD")
         ,dee0("blockF_dee0", "blockD")
         ,dee1("blockF_dee1", "blockD")
-        ,rwD("blockF_rwD", "blockBRegs")
+        ,rwD("rwD", "blockBRegs")
         ,roBsize("blockBRegs_roBsize", "blockBRegs")
         ,cStuffIf_uBlockF0_uThreeCs("threeCs_cStuffIf_uBlockF0_uThreeCs", "blockF")
         ,cStuffIf_uBlockF1_uThreeCs("threeCs_cStuffIf_uBlockF1_uThreeCs", "blockF")

--- a/templates/systemc/constructor.py
+++ b/templates/systemc/constructor.py
@@ -68,12 +68,17 @@ def constructorInit(args, prj, data):
         else:
             channelBase = value["channelName"]
         #channelBase += "_chnl"
+        dst = None
         for k, v in value["ends"].items():
             if v["direction"] == "src":
                 src = v["instanceType"]
             else:
                 dst = v["instanceType"]
-        channelTitle = dst + "_" + channelBase
+
+        if dst is None:
+            printWarning(f"warning: connection {key} missing dst instance")
+
+        channelTitle = dst + "_" + channelBase if dst else channelBase
         extra = ''
         # we may have a multicycle interface
         if 'interfaceKey' in value:


### PR DESCRIPTION
This is a workaround for use with the existing blockData(). This workaround should be removed once issue #31 is completed