### PR TITLE
#46: safe handling of instance source assignment with all channel types

### DIFF
--- a/templates/systemc/constructor.py
+++ b/templates/systemc/constructor.py
@@ -1,4 +1,5 @@
 import pysrc.intf_gen_utils as intf_gen_utils
+from pysrc.arch2codeHelper import printError, printWarning, warningAndErrorReport
 
 # Does not alter the rendering
 intf_gen_utils.LEGACY_COMPAT_MODE = True
@@ -56,11 +57,17 @@ def constructorInit(args, prj, data):
             chnl_table[chnl] = intf_gen_utils.sc_gen_block_channels(chnlInfo, prj, data)
 
             channelBase = chnl_table[chnl]['chnl_name']
-            for k, v in chnlInfo["ends"].items():
-                if v["direction"] == "src":
-                    src = v.get("instanceType") or chnlInfo.get("block", "")
-                else:
-                    dst = v.get("instanceType") or chnlInfo.get("block", "")
+            srcInstances = [v.get("instanceType") or chnlInfo.get("block", "") for v in chnlInfo["ends"].values() if v["direction"] == "src"]
+            dstInstances = [v.get("instanceType") or chnlInfo.get("block", "") for v in chnlInfo["ends"].values() if v["direction"] == "dst"]
+            if len(srcInstances) != 1 or len(dstInstances) == 0:
+                printError(f"connection {chnl!r} ({channelType}) needs exactly one src and at least one dst end")
+                exit(warningAndErrorReport())
+            src, dst = srcInstances[0], dstInstances[0]
+            if len(dstInstances) > 1:
+                printWarning(
+                    f"connection {chnl!r} ({channelType}) has multiple dst ends ({dstInstances}). "
+                    f"Channel naming will be arbitrarily using {dst!r} as the destination instance"
+                )
             channelTitle = dst + "_" + channelBase
             extra = ''
             # we may have a multicycle interface

--- a/templates/systemc/testbench.py
+++ b/templates/systemc/testbench.py
@@ -2,7 +2,7 @@
 import textwrap
 
 from pysrc.processYaml import getPortChannelName
-from pysrc.arch2codeHelper import printError
+from pysrc.arch2codeHelper import printError, warningAndErrorReport
 from pysrc.intf_gen_utils import sc_gen_block_channels, sc_connect_channels, sc_instance_includes, sc_declare_channels, get_intf_type, get_intf_defs, inverse_portdir
 
 from jinja2 import Template
@@ -70,8 +70,14 @@ def ext_sec_init(args, prj, data):
         out.append(s.format(blockName=data_['instanceType'], instName=data_['instance']))
 
     for channelType in data['connectDouble']:
-        for _,data_ in data['connectDouble'][channelType].items():
-            srcInst = data_['src']
+        for connKey,data_ in data['connectDouble'][channelType].items():
+            srcInst = None
+            for k, v in data_['ends'].items():
+                if v.get('direction') in ['src', 'out']:
+                    srcInst = v.get('instance')
+            if not srcInst:
+                printError(f"No valid instance source found for connection {connKey!r} ({channelType})")
+                exit(warningAndErrorReport())
             chnlData = sc_gen_block_channels(data_, prj, data)
             s = '   ,{chnlName}("{chnlName}", "{instName}")'
             out.append(s.format(chnlName=chnlData['chnl_name'], instName=srcInst))

--- a/templates/systemc/testbench.py
+++ b/templates/systemc/testbench.py
@@ -71,13 +71,11 @@ def ext_sec_init(args, prj, data):
 
     for channelType in data['connectDouble']:
         for connKey,data_ in data['connectDouble'][channelType].items():
-            srcInst = None
-            for k, v in data_['ends'].items():
-                if v.get('direction') in ['src', 'out']:
-                    srcInst = v.get('instance')
-            if not srcInst:
-                printError(f"No valid instance source found for connection {connKey!r} ({channelType})")
+            srcInstances = [v.get('instance') for v in data_['ends'].values() if v.get('direction') == "src"]
+            if len(srcInstances) != 1:
+                printError(f"Expected exactly one src instance for connection {connKey!r} ({channelType}), found {len(srcInstances)}")
                 exit(warningAndErrorReport())
+            srcInst = srcInstances[0]
             chnlData = sc_gen_block_channels(data_, prj, data)
             s = '   ,{chnlName}("{chnlName}", "{instName}")'
             out.append(s.format(chnlName=chnlData['chnl_name'], instName=srcInst))


### PR DESCRIPTION
From cursor AI analysis

What data_['src'] assumes
For YAML connections, _process_connections does entry = row.copy() before filling ends, and the schema does include top-level src / dst (see config/schema.yaml around the connections section). So for plain connections that still look like the parsed YAML row, data_['src'] can often match the logical source instance.

Why walking ends is stronger in this spot
1. connectDouble is not only YAML connections
connectDouble pulls from both connections and registerConnections (processYaml connMapping). Register-side links are built in getBDRegisterConnections by merging register info and building an ends dict (e.g. 1638:1650:/work/arch2code/pysrc/processYaml.py). Those structures are centered on ends and direction (regMapBlock / regMapReg), not on a guaranteed top-level 'src' field like the YAML connection row.

So srcInst = data_['src'] is not a safe universal API for every value that can appear under connectDouble: many register-derived entries won’t have the same shape as a YAML connections record, and you risk KeyError or accidentally reading some unrelated key if a merged dict ever contained src for another reason.

2. Same abstraction the rest of the SC generator uses
Channel hookup code elsewhere walks value['ends'] (e.g. sc_connect_channel_type in intf_gen_utils.py). Deriving “which instance is the source/driver side” from ends and direction matches that model instead of duplicating a second convention (top-level src).

3. Explicit semantics
The loop implements: “instance on the end marked as driver (direction in src or out)”. That is tied to role on the link, not only to the YAML column name src. (I did not find direction == 'out' set in processYaml for these paths; treating 'out' like a driver may be defensive or for another producer—either way it widens the match beyond a bare 'src' label.)

4. Fallback
If nothing matches, falling back to the first end’s instance avoids blowing up the initializer list when metadata is odd; data_['src'] has no analogous fallback.

Short summary
data_['src'] is shorter and can work for classic YAML connections that still expose that field. The ends + direction approach is better here because it works for all connectDouble members (including register connections), stays aligned with how connections are consumed elsewhere, and adds a small fallback. The tradeoff is a few more lines instead of one indexed field that is not guaranteed on every connection dict.