### PR TITLE
Convert template to use SV Codegen library - Draft PR for review / discussion only

### DIFF
--- a/examples/apbDecode/systemVerilog/apbDecode.sv
+++ b/examples/apbDecode/systemVerilog/apbDecode.sv
@@ -1,6 +1,5 @@
 // GENERATED_CODE_PARAM --block=apbDecode
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
-//module as defined by block: apbDecode
 module apbDecode
 import apbDecode_package::*;
 (

--- a/examples/apbDecode/systemVerilog/apbDecode.sv
+++ b/examples/apbDecode/systemVerilog/apbDecode.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
 //module as defined by block: apbDecode
 module apbDecode
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     apb_if.src apb_uBlockA,

--- a/examples/apbDecode/systemVerilog/blockA.sv
+++ b/examples/apbDecode/systemVerilog/blockA.sv
@@ -1,58 +1,116 @@
 // GENERATED_CODE_PARAM --block=blockA
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockA
 module blockA
-import apbDecode_package::*;
+    import apbDecode_package::*;
 (
     apb_if.dst apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    status_if #(.data_t(aRegSt)) roA();
-    status_if #(.data_t(un0ARegSt)) rwUn0A();
-    status_if #(.data_t(un0ARegSt)) roUn0A();
-    external_reg_if #(.data_t(un0ARegSt)) extA();
+
+    status_if #(
+        .data_t(aRegSt)
+    ) roA (
+    );
+
+    status_if #(
+        .data_t(un0ARegSt)
+    ) rwUn0A (
+    );
+
+    status_if #(
+        .data_t(un0ARegSt)
+    ) roUn0A (
+    );
+
+    external_reg_if #(
+        .data_t(un0ARegSt)
+    ) extA (
+    );
+
 
     // Memory Interfaces
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable0();
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable0_reg();
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATableX();
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATableX_unused();
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable1();
-    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable1_reg();
 
-// Instances
-blockARegs ublockARegs (
-    .apbReg (apbReg),
-    .blockATable0 (blockATable0_reg),
-    .blockATable1 (blockATable1_reg),
-    .roA (roA),
-    .rwUn0A (rwUn0A),
-    .roUn0A (roUn0A),
-    .extA (extA),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATable0 (
+    );
 
-// Memory Instances
-memory_dp #(.DEPTH(MEMORYA_WORDS), .data_t(aMemSt)) uBlockATable0 (
-    .mem_portA (blockATable0),
-    .mem_portB (blockATable0_reg),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATable0_reg (
+    );
 
-memory_dp #(.DEPTH(MEMORYA_WORDS), .data_t(aMemSt)) uBlockATableX (
-    .mem_portA (blockATableX),
-    .mem_portB (blockATableX_unused),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATableX (
+    );
 
-memory_dp #(.DEPTH(MEMORYA_WORDS), .data_t(aMemSt)) uBlockATable1 (
-    .mem_portA (blockATable1),
-    .mem_portB (blockATable1_reg),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATableX_unused (
+    );
+
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATable1 (
+    );
+
+    memory_if #(
+        .data_t(aMemSt),
+        .addr_t(aMemAddrSt)
+    ) blockATable1_reg (
+    );
+
+    // Instances
+
+    blockARegs ublockARegs (
+        .apbReg(apbReg),
+        .blockATable0(blockATable0_reg),
+        .blockATable1(blockATable1_reg),
+        .roA(roA),
+        .rwUn0A(rwUn0A),
+        .roUn0A(roUn0A),
+        .extA(extA),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    // Memory Instances
+
+    memory_dp #(
+        .DEPTH(MEMORYA_WORDS),
+        .data_t(aMemSt)
+    ) uBlockATable0 (
+        .mem_portA(blockATable0),
+        .mem_portB(blockATable0_reg),
+        .clk(clk)
+    );
+
+    memory_dp #(
+        .DEPTH(MEMORYA_WORDS),
+        .data_t(aMemSt)
+    ) uBlockATableX (
+        .mem_portA(blockATableX),
+        .mem_portB(blockATableX_unused),
+        .clk(clk)
+    );
+
+    memory_dp #(
+        .DEPTH(MEMORYA_WORDS),
+        .data_t(aMemSt)
+    ) uBlockATable1 (
+        .mem_portA(blockATable1),
+        .mem_portB(blockATable1_reg),
+        .clk(clk)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/systemVerilog/blockA.sv
+++ b/examples/apbDecode/systemVerilog/blockA.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockA
 module blockA
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     apb_if.dst apbReg,

--- a/examples/apbDecode/systemVerilog/blockA.sv
+++ b/examples/apbDecode/systemVerilog/blockA.sv
@@ -10,64 +10,20 @@ module blockA
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    status_if #(
-        .data_t(aRegSt)
-    ) roA (
-    );
-
-    status_if #(
-        .data_t(un0ARegSt)
-    ) rwUn0A (
-    );
-
-    status_if #(
-        .data_t(un0ARegSt)
-    ) roUn0A (
-    );
-
-    external_reg_if #(
-        .data_t(un0ARegSt)
-    ) extA (
-    );
+    status_if #(.data_t(aRegSt)) roA ();
+    status_if #(.data_t(un0ARegSt)) rwUn0A ();
+    status_if #(.data_t(un0ARegSt)) roUn0A ();
+    external_reg_if #(.data_t(un0ARegSt)) extA ();
 
 
     // Memory Interfaces
 
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATable0 (
-    );
-
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATable0_reg (
-    );
-
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATableX (
-    );
-
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATableX_unused (
-    );
-
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATable1 (
-    );
-
-    memory_if #(
-        .data_t(aMemSt),
-        .addr_t(aMemAddrSt)
-    ) blockATable1_reg (
-    );
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable0 ();
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable0_reg ();
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATableX ();
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATableX_unused ();
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable1 ();
+    memory_if #(.data_t(aMemSt), .addr_t(aMemAddrSt)) blockATable1_reg ();
 
     // Instances
 

--- a/examples/apbDecode/systemVerilog/blockARegs.sv
+++ b/examples/apbDecode/systemVerilog/blockARegs.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --block=blockARegs
 // GENERATED_CODE_BEGIN --template=moduleRegs
 module blockARegs
-    // Generated Import package statement(s)
     import apbDecode_package::*;
     #(
         parameter bit APB_READY_1WS = 0

--- a/examples/apbDecode/systemVerilog/blockB.sv
+++ b/examples/apbDecode/systemVerilog/blockB.sv
@@ -10,30 +10,14 @@ module blockB
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    status_if #(
-        .data_t(un0BRegSt)
-    ) rwUn0B (
-    );
-
-    status_if #(
-        .data_t(aSizeRegSt)
-    ) roB (
-    );
+    status_if #(.data_t(un0BRegSt)) rwUn0B ();
+    status_if #(.data_t(aSizeRegSt)) roB ();
 
 
     // Memory Interfaces
 
-    memory_if #(
-        .data_t(bMemSt),
-        .addr_t(bMemAddrSt)
-    ) blockBTable (
-    );
-
-    memory_if #(
-        .data_t(bMemSt),
-        .addr_t(bMemAddrSt)
-    ) blockBTable_reg (
-    );
+    memory_if #(.data_t(bMemSt), .addr_t(bMemAddrSt)) blockBTable ();
+    memory_if #(.data_t(bMemSt), .addr_t(bMemAddrSt)) blockBTable_reg ();
 
     // Instances
 

--- a/examples/apbDecode/systemVerilog/blockB.sv
+++ b/examples/apbDecode/systemVerilog/blockB.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockB
 module blockB
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     apb_if.dst apbReg,

--- a/examples/apbDecode/systemVerilog/blockB.sv
+++ b/examples/apbDecode/systemVerilog/blockB.sv
@@ -1,37 +1,61 @@
 // GENERATED_CODE_PARAM --block=blockB
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockB
 module blockB
-import apbDecode_package::*;
+    import apbDecode_package::*;
 (
     apb_if.dst apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    status_if #(.data_t(un0BRegSt)) rwUn0B();
-    status_if #(.data_t(aSizeRegSt)) roB();
+
+    status_if #(
+        .data_t(un0BRegSt)
+    ) rwUn0B (
+    );
+
+    status_if #(
+        .data_t(aSizeRegSt)
+    ) roB (
+    );
+
 
     // Memory Interfaces
-    memory_if #(.data_t(bMemSt), .addr_t(bMemAddrSt)) blockBTable();
-    memory_if #(.data_t(bMemSt), .addr_t(bMemAddrSt)) blockBTable_reg();
 
-// Instances
-blockBRegs ublockBRegs (
-    .apbReg (apbReg),
-    .blockBTable (blockBTable_reg),
-    .rwUn0B (rwUn0B),
-    .roB (roB),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(bMemSt),
+        .addr_t(bMemAddrSt)
+    ) blockBTable (
+    );
 
-// Memory Instances
-memory_dp #(.DEPTH(MEMORYB_WORDS), .data_t(bMemSt)) uBlockBTable (
-    .mem_portA (blockBTable),
-    .mem_portB (blockBTable_reg),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(bMemSt),
+        .addr_t(bMemAddrSt)
+    ) blockBTable_reg (
+    );
+
+    // Instances
+
+    blockBRegs ublockBRegs (
+        .apbReg(apbReg),
+        .blockBTable(blockBTable_reg),
+        .rwUn0B(rwUn0B),
+        .roB(roB),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    // Memory Instances
+
+    memory_dp #(
+        .DEPTH(MEMORYB_WORDS),
+        .data_t(bMemSt)
+    ) uBlockBTable (
+        .mem_portA(blockBTable),
+        .mem_portB(blockBTable_reg),
+        .clk(clk)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/systemVerilog/blockBRegs.sv
+++ b/examples/apbDecode/systemVerilog/blockBRegs.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --block=blockBRegs
 // GENERATED_CODE_BEGIN --template=moduleRegs
 module blockBRegs
-    // Generated Import package statement(s)
     import apbDecode_package::*;
     #(
         parameter bit APB_READY_1WS = 0

--- a/examples/apbDecode/systemVerilog/cpu.sv
+++ b/examples/apbDecode/systemVerilog/cpu.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: cpu
 module cpu
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     apb_if.src apbReg,

--- a/examples/apbDecode/systemVerilog/cpu.sv
+++ b/examples/apbDecode/systemVerilog/cpu.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=cpu
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: cpu
 module cpu
-import apbDecode_package::*;
+    import apbDecode_package::*;
 (
     apb_if.src apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule : cpu

--- a/examples/apbDecode/systemVerilog/someRapper.sv
+++ b/examples/apbDecode/systemVerilog/someRapper.sv
@@ -1,37 +1,49 @@
 // GENERATED_CODE_PARAM --block=someRapper
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: someRapper
 module someRapper
-import apbDecode_package::*;
+    import apbDecode_package::*;
 (
     apb_if.dst apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockA();
-    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockB();
 
-// Instances
-apbDecode uAPBDecode (
-    .apbReg (apbReg),
-    .apb_uBlockA (apb_uBlockA),
-    .apb_uBlockB (apb_uBlockB),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    apb_if #(
+        .addr_t(apbAddrSt),
+        .data_t(apbDataSt)
+    ) apb_uBlockA (
+    );
 
-blockA uBlockA (
-    .apbReg (apb_uBlockA),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    apb_if #(
+        .addr_t(apbAddrSt),
+        .data_t(apbDataSt)
+    ) apb_uBlockB (
+    );
 
-blockB uBlockB (
-    .apbReg (apb_uBlockB),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+
+    // Instances
+
+    apbDecode uAPBDecode (
+        .apbReg(apbReg),
+        .apb_uBlockA(apb_uBlockA),
+        .apb_uBlockB(apb_uBlockB),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockA uBlockA (
+        .apbReg(apb_uBlockA),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockB uBlockB (
+        .apbReg(apb_uBlockB),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/systemVerilog/someRapper.sv
+++ b/examples/apbDecode/systemVerilog/someRapper.sv
@@ -10,17 +10,8 @@ module someRapper
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    apb_if #(
-        .addr_t(apbAddrSt),
-        .data_t(apbDataSt)
-    ) apb_uBlockA (
-    );
-
-    apb_if #(
-        .addr_t(apbAddrSt),
-        .data_t(apbDataSt)
-    ) apb_uBlockB (
-    );
+    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockA ();
+    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockB ();
 
 
     // Instances
@@ -33,17 +24,8 @@ module someRapper
         .rst_n(rst_n)
     );
 
-    blockA uBlockA (
-        .apbReg(apb_uBlockA),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockB uBlockB (
-        .apbReg(apb_uBlockB),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockA uBlockA (.apbReg(apb_uBlockA), .clk(clk), .rst_n(rst_n));
+    blockB uBlockB (.apbReg(apb_uBlockB), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/systemVerilog/someRapper.sv
+++ b/examples/apbDecode/systemVerilog/someRapper.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: someRapper
 module someRapper
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     apb_if.dst apbReg,

--- a/examples/apbDecode/systemVerilog/top.sv
+++ b/examples/apbDecode/systemVerilog/top.sv
@@ -9,26 +9,13 @@ module top
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    apb_if #(
-        .addr_t(apbAddrSt),
-        .data_t(apbDataSt)
-    ) apbReg (
-    );
+    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apbReg ();
 
 
     // Instances
 
-    cpu uCPU (
-        .apbReg(apbReg),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    someRapper uSomeRapper (
-        .apbReg(apbReg),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    cpu uCPU (.apbReg(apbReg), .clk(clk), .rst_n(rst_n));
+    someRapper uSomeRapper (.apbReg(apbReg), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/systemVerilog/top.sv
+++ b/examples/apbDecode/systemVerilog/top.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
-// Generated Import package statement(s)
 import apbDecode_package::*;
 (
     input clk, rst_n

--- a/examples/apbDecode/systemVerilog/top.sv
+++ b/examples/apbDecode/systemVerilog/top.sv
@@ -1,27 +1,34 @@
 // GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: top
 module top
-import apbDecode_package::*;
+    import apbDecode_package::*;
 (
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apbReg();
 
-// Instances
-cpu uCPU (
-    .apbReg (apbReg),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    apb_if #(
+        .addr_t(apbAddrSt),
+        .data_t(apbDataSt)
+    ) apbReg (
+    );
 
-someRapper uSomeRapper (
-    .apbReg (apbReg),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+
+    // Instances
+
+    cpu uCPU (
+        .apbReg(apbReg),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    someRapper uSomeRapper (
+        .apbReg(apbReg),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/apbDecode/verif/vl_wrap/blocks/apbDecode_hdl_sv_wrapper.sv
+++ b/examples/apbDecode/verif/vl_wrap/blocks/apbDecode_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module apbDecode_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import apbDecode_package::*;
 (
     // apb_if.src

--- a/examples/apbDecode/verif/vl_wrap/blocks/blockA_hdl_sv_wrapper.sv
+++ b/examples/apbDecode/verif/vl_wrap/blocks/blockA_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module blockA_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import apbDecode_package::*;
 (
     // apb_if.dst

--- a/examples/apbDecode/verif/vl_wrap/blocks/blockB_hdl_sv_wrapper.sv
+++ b/examples/apbDecode/verif/vl_wrap/blocks/blockB_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module blockB_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import apbDecode_package::*;
 (
     // apb_if.dst

--- a/examples/apbDecode/verif/vl_wrap/blocks/someRapper_hdl_sv_wrapper.sv
+++ b/examples/apbDecode/verif/vl_wrap/blocks/someRapper_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module someRapper_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import apbDecode_package::*;
 (
     // apb_if.dst

--- a/examples/axi4sDemo/rtl/axi4sDemo.sv
+++ b/examples/axi4sDemo/rtl/axi4sDemo.sv
@@ -4,7 +4,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: axi4sDemo
 module axi4sDemo
-// Generated Import package statement(s)
 import axi4sDemo_tb_package::*;
 (
     axi4_stream_if.dst axis4_t1,

--- a/examples/axi4sDemo/rtl/axi4sDemo.sv
+++ b/examples/axi4sDemo/rtl/axi4sDemo.sv
@@ -2,18 +2,19 @@
 
 // GENERATED_CODE_PARAM --block=axi4sDemo
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: axi4sDemo
 module axi4sDemo
-import axi4sDemo_tb_package::*;
+    import axi4sDemo_tb_package::*;
 (
     axi4_stream_if.dst axis4_t1,
     axi4_stream_if.src axis4_t2,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
     localparam int SRC_DATA_WIDTH = 256;

--- a/examples/axi4sDemo/verif/vl_wrap/axi4sDemo_hdl_sv_wrapper.sv
+++ b/examples/axi4sDemo/verif/vl_wrap/axi4sDemo_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module axi4sDemo_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import axi4sDemo_tb_package::*;
 (
     // axi4_stream_if.dst

--- a/examples/axiDemo/systemVerilog/axiDemo_package.sv
+++ b/examples/axiDemo/systemVerilog/axiDemo_package.sv
@@ -3,7 +3,6 @@
 // GENERATED_CODE_PARAM --context=axiDemo.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package axiDemo_package;
-// Generated Import package statement(s)
 import axiStd_package::*;
 localparam int unsigned AXI_ADDRESS_WIDTH = 32'h0000_0020;  // The width of the AXI address busses
 localparam int unsigned AXI_DATA_WIDTH = 32'h0000_0020;  // The width of the AXI data busses

--- a/examples/axiDemo/systemVerilog/consumer.sv
+++ b/examples/axiDemo/systemVerilog/consumer.sv
@@ -1,8 +1,7 @@
 // GENERATED_CODE_PARAM --block=consumer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: consumer
 module consumer
-import axiDemo_package::*;
+    import axiDemo_package::*;
 (
     axi_read_if.dst axiRd0,
     axi_read_if.dst axiRd1,
@@ -14,12 +13,14 @@ import axiDemo_package::*;
     axi_write_if.dst axiWr3,
     axi4_stream_if.dst axiStr0,
     axi4_stream_if.dst axiStr1,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: consumer

--- a/examples/axiDemo/systemVerilog/consumer.sv
+++ b/examples/axiDemo/systemVerilog/consumer.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: consumer
 module consumer
-// Generated Import package statement(s)
 import axiDemo_package::*;
 (
     axi_read_if.dst axiRd0,

--- a/examples/axiDemo/systemVerilog/producer.sv
+++ b/examples/axiDemo/systemVerilog/producer.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: producer
 module producer
-// Generated Import package statement(s)
 import axiDemo_package::*;
 (
     axi_read_if.src axiRd0,

--- a/examples/axiDemo/systemVerilog/producer.sv
+++ b/examples/axiDemo/systemVerilog/producer.sv
@@ -1,8 +1,7 @@
 // GENERATED_CODE_PARAM --block=producer
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: producer
 module producer
-import axiDemo_package::*;
+    import axiDemo_package::*;
 (
     axi_read_if.src axiRd0,
     axi_read_if.src axiRd1,
@@ -14,12 +13,14 @@ import axiDemo_package::*;
     axi_write_if.src axiWr3,
     axi4_stream_if.src axiStr0,
     axi4_stream_if.src axiStr1,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: producer

--- a/examples/axiDemo/systemVerilog/top.sv
+++ b/examples/axiDemo/systemVerilog/top.sv
@@ -1,54 +1,114 @@
 // GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: top
 module top
-import axiDemo_package::*;
+    import axiDemo_package::*;
 (
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd0();
-    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd1();
-    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd2();
-    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd3();
-    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr0();
-    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr1();
-    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr2();
-    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr3();
-    axi4_stream_if #(.tdata_t(axiDataSt), .tid_t(axiAddrSt), .tdest_t(axiAddrSt), .tuser_t(axiAddrSt)) axiStr0();
-    axi4_stream_if #(.tdata_t(axiDataSt), .tid_t(axiAddrSt), .tdest_t(axiAddrSt), .tuser_t(axiAddrSt)) axiStr1();
 
-// Instances
-producer uProducer (
-    .axiRd0 (axiRd0),
-    .axiRd1 (axiRd1),
-    .axiRd2 (axiRd2),
-    .axiRd3 (axiRd3),
-    .axiWr0 (axiWr0),
-    .axiWr1 (axiWr1),
-    .axiWr2 (axiWr2),
-    .axiWr3 (axiWr3),
-    .axiStr0 (axiStr0),
-    .axiStr1 (axiStr1),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    axi_read_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt)
+    ) axiRd0 (
+    );
 
-consumer uConsumer (
-    .axiRd0 (axiRd0),
-    .axiRd1 (axiRd1),
-    .axiRd2 (axiRd2),
-    .axiRd3 (axiRd3),
-    .axiWr0 (axiWr0),
-    .axiWr1 (axiWr1),
-    .axiWr2 (axiWr2),
-    .axiWr3 (axiWr3),
-    .axiStr0 (axiStr0),
-    .axiStr1 (axiStr1),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    axi_read_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt)
+    ) axiRd1 (
+    );
+
+    axi_read_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt)
+    ) axiRd2 (
+    );
+
+    axi_read_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt)
+    ) axiRd3 (
+    );
+
+    axi_write_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt),
+        .strb_t(axiStrobeSt)
+    ) axiWr0 (
+    );
+
+    axi_write_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt),
+        .strb_t(axiStrobeSt)
+    ) axiWr1 (
+    );
+
+    axi_write_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt),
+        .strb_t(axiStrobeSt)
+    ) axiWr2 (
+    );
+
+    axi_write_if #(
+        .addr_t(axiAddrSt),
+        .data_t(axiDataSt),
+        .strb_t(axiStrobeSt)
+    ) axiWr3 (
+    );
+
+    axi4_stream_if #(
+        .tdata_t(axiDataSt),
+        .tid_t(axiAddrSt),
+        .tdest_t(axiAddrSt),
+        .tuser_t(axiAddrSt)
+    ) axiStr0 (
+    );
+
+    axi4_stream_if #(
+        .tdata_t(axiDataSt),
+        .tid_t(axiAddrSt),
+        .tdest_t(axiAddrSt),
+        .tuser_t(axiAddrSt)
+    ) axiStr1 (
+    );
+
+
+    // Instances
+
+    producer uProducer (
+        .axiRd0(axiRd0),
+        .axiRd1(axiRd1),
+        .axiRd2(axiRd2),
+        .axiRd3(axiRd3),
+        .axiWr0(axiWr0),
+        .axiWr1(axiWr1),
+        .axiWr2(axiWr2),
+        .axiWr3(axiWr3),
+        .axiStr0(axiStr0),
+        .axiStr1(axiStr1),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    consumer uConsumer (
+        .axiRd0(axiRd0),
+        .axiRd1(axiRd1),
+        .axiRd2(axiRd2),
+        .axiRd3(axiRd3),
+        .axiWr0(axiWr0),
+        .axiWr1(axiWr1),
+        .axiWr2(axiWr2),
+        .axiWr3(axiWr3),
+        .axiStr0(axiStr0),
+        .axiStr1(axiStr1),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 endmodule: top

--- a/examples/axiDemo/systemVerilog/top.sv
+++ b/examples/axiDemo/systemVerilog/top.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
-// Generated Import package statement(s)
 import axiDemo_package::*;
 (
     input clk, rst_n

--- a/examples/axiDemo/systemVerilog/top.sv
+++ b/examples/axiDemo/systemVerilog/top.sv
@@ -9,57 +9,14 @@ module top
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    axi_read_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt)
-    ) axiRd0 (
-    );
-
-    axi_read_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt)
-    ) axiRd1 (
-    );
-
-    axi_read_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt)
-    ) axiRd2 (
-    );
-
-    axi_read_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt)
-    ) axiRd3 (
-    );
-
-    axi_write_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt),
-        .strb_t(axiStrobeSt)
-    ) axiWr0 (
-    );
-
-    axi_write_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt),
-        .strb_t(axiStrobeSt)
-    ) axiWr1 (
-    );
-
-    axi_write_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt),
-        .strb_t(axiStrobeSt)
-    ) axiWr2 (
-    );
-
-    axi_write_if #(
-        .addr_t(axiAddrSt),
-        .data_t(axiDataSt),
-        .strb_t(axiStrobeSt)
-    ) axiWr3 (
-    );
+    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd0 ();
+    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd1 ();
+    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd2 ();
+    axi_read_if #(.addr_t(axiAddrSt), .data_t(axiDataSt)) axiRd3 ();
+    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr0 ();
+    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr1 ();
+    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr2 ();
+    axi_write_if #(.addr_t(axiAddrSt), .data_t(axiDataSt), .strb_t(axiStrobeSt)) axiWr3 ();
 
     axi4_stream_if #(
         .tdata_t(axiDataSt),

--- a/examples/axiDemo/systemVerilog/top.sv
+++ b/examples/axiDemo/systemVerilog/top.sv
@@ -23,16 +23,14 @@ module top
         .tid_t(axiAddrSt),
         .tdest_t(axiAddrSt),
         .tuser_t(axiAddrSt)
-    ) axiStr0 (
-    );
+    ) axiStr0 ();
 
     axi4_stream_if #(
         .tdata_t(axiDataSt),
         .tid_t(axiAddrSt),
         .tdest_t(axiAddrSt),
         .tuser_t(axiAddrSt)
-    ) axiStr1 (
-    );
+    ) axiStr1 ();
 
 
     // Instances

--- a/examples/axiDemo/verif/vl_wrap/blocks/consumer_hdl_sv_wrapper.sv
+++ b/examples/axiDemo/verif/vl_wrap/blocks/consumer_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module consumer_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import axiDemo_package::*;
 (
     // axi_read_if.dst

--- a/examples/axiDemo/verif/vl_wrap/blocks/producer_hdl_sv_wrapper.sv
+++ b/examples/axiDemo/verif/vl_wrap/blocks/producer_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module producer_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import axiDemo_package::*;
 (
     // axi_read_if.src

--- a/examples/hierInclude/systemVerilog/b/blockBX.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBX.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBX
 module blockBX
-// Generated Import package statement(s)
 import hierIncludeB_package::*;
 import hierInclude_package::*;
 (

--- a/examples/hierInclude/systemVerilog/b/blockBX.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBX.sv
@@ -1,20 +1,21 @@
 // GENERATED_CODE_PARAM --block=blockBX
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockBX
 module blockBX
-import hierIncludeB_package::*;
-import hierInclude_package::*;
+    import hierIncludeB_package::*;
+    import hierInclude_package::*;
 (
     rdy_vld_if.src bx2y,
     rdy_vld_if.src bx2z,
     rdy_vld_if.dst anInterface,
     req_ack_if.src b2C,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockBX

--- a/examples/hierInclude/systemVerilog/b/blockBY.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBY.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=blockBY
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockBY
 module blockBY
-import hierIncludeB_package::*;
+    import hierIncludeB_package::*;
 (
     rdy_vld_if.dst x,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockBY

--- a/examples/hierInclude/systemVerilog/b/blockBY.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBY.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBY
 module blockBY
-// Generated Import package statement(s)
 import hierIncludeB_package::*;
 (
     rdy_vld_if.dst x,

--- a/examples/hierInclude/systemVerilog/b/blockBZ.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBZ.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockBZ
 module blockBZ
-// Generated Import package statement(s)
 import hierIncludeB_package::*;
 (
     rdy_vld_if.dst x,

--- a/examples/hierInclude/systemVerilog/b/blockBZ.sv
+++ b/examples/hierInclude/systemVerilog/b/blockBZ.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=blockBZ
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockBZ
 module blockBZ
-import hierIncludeB_package::*;
+    import hierIncludeB_package::*;
 (
     rdy_vld_if.dst x,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockBZ

--- a/examples/hierInclude/systemVerilog/b/hierIncludeB_package.sv
+++ b/examples/hierInclude/systemVerilog/b/hierIncludeB_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context b/hierIncludeB.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeB_package;
-// Generated Import package statement(s)
 import hierIncludeTop_package::*;
 import hierInclude_package::*;
 import hierIncludeBInclude_package::*;

--- a/examples/hierInclude/systemVerilog/blockA.sv
+++ b/examples/hierInclude/systemVerilog/blockA.sv
@@ -1,17 +1,18 @@
 // GENERATED_CODE_PARAM --block=blockA
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockA
 module blockA
-import hierInclude_package::*;
+    import hierInclude_package::*;
 (
     rdy_vld_if.src anInterfaceB,
     rdy_vld_if.src anInterfaceC,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockA

--- a/examples/hierInclude/systemVerilog/blockA.sv
+++ b/examples/hierInclude/systemVerilog/blockA.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockA
 module blockA
-// Generated Import package statement(s)
 import hierInclude_package::*;
 (
     rdy_vld_if.src anInterfaceB,

--- a/examples/hierInclude/systemVerilog/blockB.sv
+++ b/examples/hierInclude/systemVerilog/blockB.sv
@@ -12,15 +12,8 @@ module blockB
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    rdy_vld_if #(
-        .data_t(bSt)
-    ) bx2y (
-    );
-
-    rdy_vld_if #(
-        .data_t(bSt)
-    ) bx2z (
-    );
+    rdy_vld_if #(.data_t(bSt)) bx2y ();
+    rdy_vld_if #(.data_t(bSt)) bx2z ();
 
 
     // Instances
@@ -34,17 +27,8 @@ module blockB
         .rst_n(rst_n)
     );
 
-    blockBY uBlockBY (
-        .x(bx2y),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockBZ uBlockBZ (
-        .x(bx2z),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockBY uBlockBY (.x(bx2y), .clk(clk), .rst_n(rst_n));
+    blockBZ uBlockBZ (.x(bx2z), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/hierInclude/systemVerilog/blockB.sv
+++ b/examples/hierInclude/systemVerilog/blockB.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockB
 module blockB
-// Generated Import package statement(s)
 import hierIncludeB_package::*;
 import hierInclude_package::*;
 (

--- a/examples/hierInclude/systemVerilog/blockB.sv
+++ b/examples/hierInclude/systemVerilog/blockB.sv
@@ -1,40 +1,50 @@
 // GENERATED_CODE_PARAM --block=blockB
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockB
 module blockB
-import hierIncludeB_package::*;
-import hierInclude_package::*;
+    import hierIncludeB_package::*;
+    import hierInclude_package::*;
 (
     rdy_vld_if.dst eh2b,
     req_ack_if.src b2C,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    rdy_vld_if #(.data_t(bSt)) bx2y();
-    rdy_vld_if #(.data_t(bSt)) bx2z();
 
-// Instances
-blockBX uBlockBX (
-    .anInterface (eh2b),
-    .b2C (b2C),
-    .bx2y (bx2y),
-    .bx2z (bx2z),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(bSt)
+    ) bx2y (
+    );
 
-blockBY uBlockBY (
-    .x (bx2y),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(bSt)
+    ) bx2z (
+    );
 
-blockBZ uBlockBZ (
-    .x (bx2z),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+
+    // Instances
+
+    blockBX uBlockBX (
+        .anInterface(eh2b),
+        .b2C(b2C),
+        .bx2y(bx2y),
+        .bx2z(bx2z),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockBY uBlockBY (
+        .x(bx2y),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockBZ uBlockBZ (
+        .x(bx2z),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/hierInclude/systemVerilog/blockC.sv
+++ b/examples/hierInclude/systemVerilog/blockC.sv
@@ -12,15 +12,8 @@ module blockC
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    rdy_vld_if #(
-        .data_t(cSt)
-    ) cx2y (
-    );
-
-    rdy_vld_if #(
-        .data_t(cSt)
-    ) cx2z (
-    );
+    rdy_vld_if #(.data_t(cSt)) cx2y ();
+    rdy_vld_if #(.data_t(cSt)) cx2z ();
 
 
     // Instances
@@ -34,17 +27,8 @@ module blockC
         .rst_n(rst_n)
     );
 
-    blockCY uBlockCY (
-        .x(cx2y),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockCZ uBlockCZ (
-        .x(cx2z),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockCY uBlockCY (.x(cx2y), .clk(clk), .rst_n(rst_n));
+    blockCZ uBlockCZ (.x(cx2z), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/hierInclude/systemVerilog/blockC.sv
+++ b/examples/hierInclude/systemVerilog/blockC.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockC
 module blockC
-// Generated Import package statement(s)
 import hierIncludeC_package::*;
 import hierInclude_package::*;
 (

--- a/examples/hierInclude/systemVerilog/blockC.sv
+++ b/examples/hierInclude/systemVerilog/blockC.sv
@@ -1,40 +1,50 @@
 // GENERATED_CODE_PARAM --block=blockC
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockC
 module blockC
-import hierIncludeC_package::*;
-import hierInclude_package::*;
+    import hierIncludeC_package::*;
+    import hierInclude_package::*;
 (
     rdy_vld_if.dst eh2c,
     req_ack_if.dst b2C,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    rdy_vld_if #(.data_t(cSt)) cx2y();
-    rdy_vld_if #(.data_t(cSt)) cx2z();
 
-// Instances
-blockCX uBlockCX (
-    .anInterface (eh2c),
-    .b2C (b2C),
-    .cx2y (cx2y),
-    .cx2z (cx2z),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(cSt)
+    ) cx2y (
+    );
 
-blockCY uBlockCY (
-    .x (cx2y),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(cSt)
+    ) cx2z (
+    );
 
-blockCZ uBlockCZ (
-    .x (cx2z),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+
+    // Instances
+
+    blockCX uBlockCX (
+        .anInterface(eh2c),
+        .b2C(b2C),
+        .cx2y(cx2y),
+        .cx2z(cx2z),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockCY uBlockCY (
+        .x(cx2y),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockCZ uBlockCZ (
+        .x(cx2z),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/hierInclude/systemVerilog/c/blockCX.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCX.sv
@@ -2,10 +2,8 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockCX
 module blockCX
-// Generated Import package statement(s)
 import hierIncludeC_package::*;
 import hierInclude_package::*;
-// User supplied Import package statement(s)
 import hierIncludeCInclude_package::*;
 (
     rdy_vld_if.src cx2y,

--- a/examples/hierInclude/systemVerilog/c/blockCX.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCX.sv
@@ -1,21 +1,22 @@
 // GENERATED_CODE_PARAM --block=blockCX --importPackage=hierIncludeCInclude_package
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockCX
 module blockCX
-import hierIncludeC_package::*;
-import hierInclude_package::*;
-import hierIncludeCInclude_package::*;
+    import hierIncludeC_package::*;
+    import hierInclude_package::*;
+    import hierIncludeCInclude_package::*;
 (
     rdy_vld_if.src cx2y,
     rdy_vld_if.src cx2z,
     rdy_vld_if.dst anInterface,
     req_ack_if.dst b2C,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 

--- a/examples/hierInclude/systemVerilog/c/blockCY.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCY.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=blockCY
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockCY
 module blockCY
-import hierIncludeC_package::*;
+    import hierIncludeC_package::*;
 (
     rdy_vld_if.dst x,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockCY

--- a/examples/hierInclude/systemVerilog/c/blockCY.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCY.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockCY
 module blockCY
-// Generated Import package statement(s)
 import hierIncludeC_package::*;
 (
     rdy_vld_if.dst x,

--- a/examples/hierInclude/systemVerilog/c/blockCZ.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCZ.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockCZ
 module blockCZ
-// Generated Import package statement(s)
 import hierIncludeC_package::*;
 (
     rdy_vld_if.dst x,

--- a/examples/hierInclude/systemVerilog/c/blockCZ.sv
+++ b/examples/hierInclude/systemVerilog/c/blockCZ.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=blockCZ
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockCZ
 module blockCZ
-import hierIncludeC_package::*;
+    import hierIncludeC_package::*;
 (
     rdy_vld_if.dst x,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockCZ

--- a/examples/hierInclude/systemVerilog/c/hierIncludeC_package.sv
+++ b/examples/hierInclude/systemVerilog/c/hierIncludeC_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context c/hierIncludeC.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeC_package;
-// Generated Import package statement(s)
 import hierIncludeTop_package::*;
 import hierInclude_package::*;
 import hierIncludeCInclude_package::*;

--- a/examples/hierInclude/systemVerilog/hierIncludeTop_package.sv
+++ b/examples/hierInclude/systemVerilog/hierIncludeTop_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context hierIncludeTop.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierIncludeTop_package;
-// Generated Import package statement(s)
 import hierIncludeNestedTop_package::*;
 localparam int unsigned ANOTHER_SIZE = 32'h0000_0004;  // The size for another size
 

--- a/examples/hierInclude/systemVerilog/hierInclude_package.sv
+++ b/examples/hierInclude/systemVerilog/hierInclude_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context hierInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package hierInclude_package;
-// Generated Import package statement(s)
 import hierIncludeNestedTop_package::*;
 import hierIncludeTop_package::*;
 localparam int unsigned ASIZE = 32'h0000_0007;  // The size of A

--- a/examples/hierInclude/systemVerilog/top.sv
+++ b/examples/hierInclude/systemVerilog/top.sv
@@ -9,21 +9,9 @@ module top
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    rdy_vld_if #(
-        .data_t(aSt)
-    ) anInterfaceB (
-    );
-
-    rdy_vld_if #(
-        .data_t(aSt)
-    ) anInterfaceC (
-    );
-
-    req_ack_if #(
-        .data_t(anotherSt),
-        .rdata_t(yetAnotherSt)
-    ) b2C (
-    );
+    rdy_vld_if #(.data_t(aSt)) anInterfaceB ();
+    rdy_vld_if #(.data_t(aSt)) anInterfaceC ();
+    req_ack_if #(.data_t(anotherSt), .rdata_t(yetAnotherSt)) b2C ();
 
 
     // Instances
@@ -35,19 +23,8 @@ module top
         .rst_n(rst_n)
     );
 
-    blockB uBlockB (
-        .eh2b(anInterfaceB),
-        .b2C(b2C),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockC uBlockC (
-        .eh2c(anInterfaceC),
-        .b2C(b2C),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockB uBlockB (.eh2b(anInterfaceB), .b2C(b2C), .clk(clk), .rst_n(rst_n));
+    blockC uBlockC (.eh2c(anInterfaceC), .b2C(b2C), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/hierInclude/systemVerilog/top.sv
+++ b/examples/hierInclude/systemVerilog/top.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: top
 module top
-// Generated Import package statement(s)
 import hierInclude_package::*;
 (
     input clk, rst_n

--- a/examples/hierInclude/systemVerilog/top.sv
+++ b/examples/hierInclude/systemVerilog/top.sv
@@ -1,38 +1,53 @@
 // GENERATED_CODE_PARAM --block=top
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: top
 module top
-import hierInclude_package::*;
+    import hierInclude_package::*;
 (
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    rdy_vld_if #(.data_t(aSt)) anInterfaceB();
-    rdy_vld_if #(.data_t(aSt)) anInterfaceC();
-    req_ack_if #(.data_t(anotherSt), .rdata_t(yetAnotherSt)) b2C();
 
-// Instances
-blockA uBlockA (
-    .anInterfaceB (anInterfaceB),
-    .anInterfaceC (anInterfaceC),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(aSt)
+    ) anInterfaceB (
+    );
 
-blockB uBlockB (
-    .eh2b (anInterfaceB),
-    .b2C (b2C),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(aSt)
+    ) anInterfaceC (
+    );
 
-blockC uBlockC (
-    .eh2c (anInterfaceC),
-    .b2C (b2C),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    req_ack_if #(
+        .data_t(anotherSt),
+        .rdata_t(yetAnotherSt)
+    ) b2C (
+    );
+
+
+    // Instances
+
+    blockA uBlockA (
+        .anInterfaceB(anInterfaceB),
+        .anInterfaceC(anInterfaceC),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockB uBlockB (
+        .eh2b(anInterfaceB),
+        .b2C(b2C),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockC uBlockC (
+        .eh2c(anInterfaceC),
+        .b2C(b2C),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/inAndOut/systemVerilog/inAndOut.sv
+++ b/examples/inAndOut/systemVerilog/inAndOut.sv
@@ -1,8 +1,7 @@
 // GENERATED_CODE_PARAM --block=inAndOut
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: inAndOut
 module inAndOut
-import inAndOut_package::*;
+    import inAndOut_package::*;
 (
     rdy_vld_if.src aOut,
     rdy_vld_if.dst aIn,
@@ -10,12 +9,14 @@ import inAndOut_package::*;
     req_ack_if.dst bIn,
     pop_ack_if.src dOut,
     pop_ack_if.dst dIn,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: inAndOut

--- a/examples/inAndOut/systemVerilog/inAndOut.sv
+++ b/examples/inAndOut/systemVerilog/inAndOut.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: inAndOut
 module inAndOut
-// Generated Import package statement(s)
 import inAndOut_package::*;
 (
     rdy_vld_if.src aOut,

--- a/examples/inAndOut/systemVerilog/simInAndOut/inAndOut_hdl_sv_wrapper.sv
+++ b/examples/inAndOut/systemVerilog/simInAndOut/inAndOut_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module inAndOut_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import inAndOut_package::*;
 (
     // rdy_vld_if.src

--- a/examples/mixed/rtl/apbDecode.sv
+++ b/examples/mixed/rtl/apbDecode.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
 //module as defined by block: apbDecode
 module apbDecode
-// Generated Import package statement(s)
 import mixed_package::*;
 (
     apb_if.src apb_uBlockA,

--- a/examples/mixed/rtl/apbDecode.sv
+++ b/examples/mixed/rtl/apbDecode.sv
@@ -1,6 +1,5 @@
 // GENERATED_CODE_PARAM --block=apbDecode
 // GENERATED_CODE_BEGIN --template=apbDecodeModule
-//module as defined by block: apbDecode
 module apbDecode
 import mixed_package::*;
 (

--- a/examples/mixed/rtl/blockA.sv
+++ b/examples/mixed/rtl/blockA.sv
@@ -16,22 +16,9 @@ module blockA
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    status_if #(
-        .data_t(aRegSt)
-    ) roA (
-    );
-
-    memory_if #(
-        .data_t(aRegSt),
-        .addr_t(bSizeSt)
-    ) blockATableLocal (
-    );
-
-    memory_if #(
-        .data_t(test37BitRegSt),
-        .addr_t(bSizeSt)
-    ) blockATable37Bit (
-    );
+    status_if #(.data_t(aRegSt)) roA ();
+    memory_if #(.data_t(aRegSt), .addr_t(bSizeSt)) blockATableLocal ();
+    memory_if #(.data_t(test37BitRegSt), .addr_t(bSizeSt)) blockATable37Bit ();
 
 
     // Instances

--- a/examples/mixed/rtl/blockA.sv
+++ b/examples/mixed/rtl/blockA.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockA
 module blockA
-// Generated Import package statement(s)
 import mixedInclude_package::*;
 import mixedBlockC_package::*;
 import mixed_package::*;

--- a/examples/mixed/rtl/blockA.sv
+++ b/examples/mixed/rtl/blockA.sv
@@ -1,33 +1,49 @@
 // GENERATED_CODE_PARAM --block=blockA
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockA
 module blockA
-import mixedInclude_package::*;
-import mixedBlockC_package::*;
-import mixed_package::*;
+    import mixedInclude_package::*;
+    import mixedBlockC_package::*;
+    import mixed_package::*;
 (
     req_ack_if.src aStuffIf,
     rdy_vld_if.src cStuffIf,
     notify_ack_if.src startDone,
     rdy_vld_if.src dupIf,
     apb_if.dst apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    status_if #(.data_t(aRegSt)) roA();
-    memory_if #(.data_t(aRegSt), .addr_t(bSizeSt)) blockATableLocal();
-    memory_if #(.data_t(test37BitRegSt), .addr_t(bSizeSt)) blockATable37Bit();
 
-// Instances
-blockARegs uBlockARegs (
-    .apbReg (apbReg),
-    .roA (roA),
-    .blockATableLocal (blockATableLocal),
-    .blockATable37Bit (blockATable37Bit),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    status_if #(
+        .data_t(aRegSt)
+    ) roA (
+    );
+
+    memory_if #(
+        .data_t(aRegSt),
+        .addr_t(bSizeSt)
+    ) blockATableLocal (
+    );
+
+    memory_if #(
+        .data_t(test37BitRegSt),
+        .addr_t(bSizeSt)
+    ) blockATable37Bit (
+    );
+
+
+    // Instances
+
+    blockARegs uBlockARegs (
+        .apbReg(apbReg),
+        .roA(roA),
+        .blockATableLocal(blockATableLocal),
+        .blockATable37Bit(blockATable37Bit),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/rtl/blockARegs.sv
+++ b/examples/mixed/rtl/blockARegs.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --block=blockARegs
 // GENERATED_CODE_BEGIN --template=moduleRegs
 module blockARegs
-    // Generated Import package statement(s)
     import mixedInclude_package::*;
     import mixed_package::*;
     #(

--- a/examples/mixed/rtl/blockB.sv
+++ b/examples/mixed/rtl/blockB.sv
@@ -1,137 +1,264 @@
 // GENERATED_CODE_PARAM --block=blockB
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockB
 module blockB
-import mixedInclude_package::*;
-import mixedBlockC_package::*;
-import mixed_package::*;
+    import mixedInclude_package::*;
+    import mixedBlockC_package::*;
+    import mixed_package::*;
 (
     req_ack_if.dst btod,
     notify_ack_if.dst startDone,
     rdy_vld_if.dst dupIf,
     apb_if.dst apbReg,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    rdy_vld_if #(.data_t(seeSt)) cStuffIf();
-    rdy_vld_if #(.data_t(seeSt)) cStuff1();
-    rdy_vld_if #(.data_t(seeSt)) cStuff2();
-    rdy_vld_if #(.data_t(dSt)) dee0();
-    rdy_vld_if #(.data_t(dSt)) dee1();
-    rdy_vld_if #(.data_t(dSt)) loopDF();
-    rdy_vld_if #(.data_t(dSt)) loopFF();
-    rdy_vld_if #(.data_t(dSt)) loopFD();
-    status_if #(.data_t(dRegSt)) rwD();
-    status_if #(.data_t(bSizeRegSt)) roBsize();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTableExt();
-    memory_if #(.data_t(test37BitRegSt), .addr_t(bSizeSt)) blockBTable37Bit();
+
+    rdy_vld_if #(
+        .data_t(seeSt)
+    ) cStuffIf (
+    );
+
+    rdy_vld_if #(
+        .data_t(seeSt)
+    ) cStuff1 (
+    );
+
+    rdy_vld_if #(
+        .data_t(seeSt)
+    ) cStuff2 (
+    );
+
+    rdy_vld_if #(
+        .data_t(dSt)
+    ) dee0 (
+    );
+
+    rdy_vld_if #(
+        .data_t(dSt)
+    ) dee1 (
+    );
+
+    rdy_vld_if #(
+        .data_t(dSt)
+    ) loopDF (
+    );
+
+    rdy_vld_if #(
+        .data_t(dSt)
+    ) loopFF (
+    );
+
+    rdy_vld_if #(
+        .data_t(dSt)
+    ) loopFD (
+    );
+
+    status_if #(
+        .data_t(dRegSt)
+    ) rwD (
+    );
+
+    status_if #(
+        .data_t(bSizeRegSt)
+    ) roBsize (
+    );
+
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTableExt (
+    );
+
+    memory_if #(
+        .data_t(test37BitRegSt),
+        .addr_t(bSizeSt)
+    ) blockBTable37Bit (
+    );
+
 
     // Memory Interfaces
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable0();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable0_unused();
-    memory_if #(.data_t(bigSt), .addr_t(bSizeSt)) blockBTable1_port1();
-    memory_if #(.data_t(bigSt), .addr_t(bSizeSt)) blockBTable1_reg();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable2_port1();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable2_port2();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable3_read();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable3_write();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTableSP0();
-    memory_if #(.data_t(nestedSt), .addr_t(bSizeSt)) blockBTableSP_bob();
 
-// Instances
-blockD uBlockD (
-    .btod (btod),
-    .blockBTable1 (blockBTable1_port1),
-    .blockBTableSP (blockBTableSP_bob),
-    .cStuffIf (cStuffIf),
-    .dee0 (dee0),
-    .dee1 (dee1),
-    .outD (loopDF),
-    .inD (loopFD),
-    .rwD (rwD),
-    .roBsize (roBsize),
-    .blockBTableExt (blockBTableExt),
-    .blockBTable37Bit (blockBTable37Bit),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable0 (
+    );
 
-blockF #(.bob(BOB0), .fred(0)) uBlockF0 (
-    .cStuffIf (cStuff1),
-    .dStuffIf (dee0),
-    .dSin (loopDF),
-    .dSout (loopFF),
-    .rwD (rwD),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable0_unused (
+    );
 
-blockF #(.bob(BOB1), .fred(1)) uBlockF1 (
-    .cStuffIf (cStuff2),
-    .dStuffIf (dee1),
-    .dSin (loopFF),
-    .dSout (loopFD),
-    .rwD (rwD),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(bigSt),
+        .addr_t(bSizeSt)
+    ) blockBTable1_port1 (
+    );
 
-threeCs uThreeCs (
-    .see0 (cStuffIf),
-    .see1 (cStuff1),
-    .see2 (cStuff2),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(bigSt),
+        .addr_t(bSizeSt)
+    ) blockBTable1_reg (
+    );
 
-blockBRegs uBlockBRegs (
-    .apbReg (apbReg),
-    .blockBTable1 (blockBTable1_reg),
-    .rwD (rwD),
-    .roBsize (roBsize),
-    .blockBTableExt (blockBTableExt),
-    .blockBTable37Bit (blockBTable37Bit),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable2_port1 (
+    );
 
-// Memory Instances
-seeSt blockBTable0Mem [BSIZE-1:0];
-memory_dp_ext #(.DEPTH(BSIZE), .data_t(seeSt)) uBlockBTable0 (
-    .mem_portA (blockBTable0),
-    .mem_portB (blockBTable0_unused),
-    .mem (blockBTable0Mem),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable2_port2 (
+    );
 
-memory_dp #(.DEPTH(BSIZE), .data_t(bigSt)) uBlockBTable1 (
-    .mem_portA (blockBTable1_port1),
-    .mem_portB (blockBTable1_reg),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable3_read (
+    );
 
-memory_dp #(.DEPTH(BSIZE), .data_t(seeSt)) uBlockBTable2 (
-    .mem_portA (blockBTable2_port1),
-    .mem_portB (blockBTable2_port2),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTable3_write (
+    );
 
-memory_dp #(.DEPTH(BSIZE), .data_t(seeSt)) uBlockBTable3 (
-    .mem_portA (blockBTable3_read),
-    .mem_portB (blockBTable3_write),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) blockBTableSP0 (
+    );
 
-memory_sp #(.DEPTH(BSIZE), .data_t(seeSt)) uBlockBTableSP0 (
-    .mem_port (blockBTableSP0),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(nestedSt),
+        .addr_t(bSizeSt)
+    ) blockBTableSP_bob (
+    );
 
-memory_sp #(.DEPTH(BSIZE), .data_t(nestedSt)) uBlockBTableSP (
-    .mem_port (blockBTableSP_bob),
-    .clk (clk)
-);
+    // Instances
+
+    blockD uBlockD (
+        .btod(btod),
+        .blockBTable1(blockBTable1_port1),
+        .blockBTableSP(blockBTableSP_bob),
+        .cStuffIf(cStuffIf),
+        .dee0(dee0),
+        .dee1(dee1),
+        .outD(loopDF),
+        .inD(loopFD),
+        .rwD(rwD),
+        .roBsize(roBsize),
+        .blockBTableExt(blockBTableExt),
+        .blockBTable37Bit(blockBTable37Bit),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockF #(
+        .bob(BOB0),
+        .fred(0)
+    ) uBlockF0 (
+        .cStuffIf(cStuff1),
+        .dStuffIf(dee0),
+        .dSin(loopDF),
+        .dSout(loopFF),
+        .rwD(rwD),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockF #(
+        .bob(BOB1),
+        .fred(1)
+    ) uBlockF1 (
+        .cStuffIf(cStuff2),
+        .dStuffIf(dee1),
+        .dSin(loopFF),
+        .dSout(loopFD),
+        .rwD(rwD),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    threeCs uThreeCs (
+        .see0(cStuffIf),
+        .see1(cStuff1),
+        .see2(cStuff2),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockBRegs uBlockBRegs (
+        .apbReg(apbReg),
+        .blockBTable1(blockBTable1_reg),
+        .rwD(rwD),
+        .roBsize(roBsize),
+        .blockBTableExt(blockBTableExt),
+        .blockBTable37Bit(blockBTable37Bit),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    // Memory Instances
+    seeSt blockBTable0Mem [BSIZE-1:0];
+
+    memory_dp_ext #(
+        .DEPTH(BSIZE),
+        .data_t(seeSt)
+    ) uBlockBTable0 (
+        .mem_portA(blockBTable0),
+        .mem_portB(blockBTable0_unused),
+        .mem(blockBTable0Mem),
+        .clk(clk)
+    );
+
+    memory_dp #(
+        .DEPTH(BSIZE),
+        .data_t(bigSt)
+    ) uBlockBTable1 (
+        .mem_portA(blockBTable1_port1),
+        .mem_portB(blockBTable1_reg),
+        .clk(clk)
+    );
+
+    memory_dp #(
+        .DEPTH(BSIZE),
+        .data_t(seeSt)
+    ) uBlockBTable2 (
+        .mem_portA(blockBTable2_port1),
+        .mem_portB(blockBTable2_port2),
+        .clk(clk)
+    );
+
+    memory_dp #(
+        .DEPTH(BSIZE),
+        .data_t(seeSt)
+    ) uBlockBTable3 (
+        .mem_portA(blockBTable3_read),
+        .mem_portB(blockBTable3_write),
+        .clk(clk)
+    );
+
+    memory_sp #(
+        .DEPTH(BSIZE),
+        .data_t(seeSt)
+    ) uBlockBTableSP0 (
+        .mem_port(blockBTableSP0),
+        .clk(clk)
+    );
+
+    memory_sp #(
+        .DEPTH(BSIZE),
+        .data_t(nestedSt)
+    ) uBlockBTableSP (
+        .mem_port(blockBTableSP_bob),
+        .clk(clk)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/rtl/blockB.sv
+++ b/examples/mixed/rtl/blockB.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockB
 module blockB
-// Generated Import package statement(s)
 import mixedInclude_package::*;
 import mixedBlockC_package::*;
 import mixed_package::*;

--- a/examples/mixed/rtl/blockB.sv
+++ b/examples/mixed/rtl/blockB.sv
@@ -15,130 +15,32 @@ module blockB
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    rdy_vld_if #(
-        .data_t(seeSt)
-    ) cStuffIf (
-    );
-
-    rdy_vld_if #(
-        .data_t(seeSt)
-    ) cStuff1 (
-    );
-
-    rdy_vld_if #(
-        .data_t(seeSt)
-    ) cStuff2 (
-    );
-
-    rdy_vld_if #(
-        .data_t(dSt)
-    ) dee0 (
-    );
-
-    rdy_vld_if #(
-        .data_t(dSt)
-    ) dee1 (
-    );
-
-    rdy_vld_if #(
-        .data_t(dSt)
-    ) loopDF (
-    );
-
-    rdy_vld_if #(
-        .data_t(dSt)
-    ) loopFF (
-    );
-
-    rdy_vld_if #(
-        .data_t(dSt)
-    ) loopFD (
-    );
-
-    status_if #(
-        .data_t(dRegSt)
-    ) rwD (
-    );
-
-    status_if #(
-        .data_t(bSizeRegSt)
-    ) roBsize (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTableExt (
-    );
-
-    memory_if #(
-        .data_t(test37BitRegSt),
-        .addr_t(bSizeSt)
-    ) blockBTable37Bit (
-    );
+    rdy_vld_if #(.data_t(seeSt)) cStuffIf ();
+    rdy_vld_if #(.data_t(seeSt)) cStuff1 ();
+    rdy_vld_if #(.data_t(seeSt)) cStuff2 ();
+    rdy_vld_if #(.data_t(dSt)) dee0 ();
+    rdy_vld_if #(.data_t(dSt)) dee1 ();
+    rdy_vld_if #(.data_t(dSt)) loopDF ();
+    rdy_vld_if #(.data_t(dSt)) loopFF ();
+    rdy_vld_if #(.data_t(dSt)) loopFD ();
+    status_if #(.data_t(dRegSt)) rwD ();
+    status_if #(.data_t(bSizeRegSt)) roBsize ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTableExt ();
+    memory_if #(.data_t(test37BitRegSt), .addr_t(bSizeSt)) blockBTable37Bit ();
 
 
     // Memory Interfaces
 
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable0 (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable0_unused (
-    );
-
-    memory_if #(
-        .data_t(bigSt),
-        .addr_t(bSizeSt)
-    ) blockBTable1_port1 (
-    );
-
-    memory_if #(
-        .data_t(bigSt),
-        .addr_t(bSizeSt)
-    ) blockBTable1_reg (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable2_port1 (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable2_port2 (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable3_read (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTable3_write (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) blockBTableSP0 (
-    );
-
-    memory_if #(
-        .data_t(nestedSt),
-        .addr_t(bSizeSt)
-    ) blockBTableSP_bob (
-    );
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable0 ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable0_unused ();
+    memory_if #(.data_t(bigSt), .addr_t(bSizeSt)) blockBTable1_port1 ();
+    memory_if #(.data_t(bigSt), .addr_t(bSizeSt)) blockBTable1_reg ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable2_port1 ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable2_port2 ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable3_read ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTable3_write ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) blockBTableSP0 ();
+    memory_if #(.data_t(nestedSt), .addr_t(bSizeSt)) blockBTableSP_bob ();
 
     // Instances
 
@@ -185,13 +87,7 @@ module blockB
         .rst_n(rst_n)
     );
 
-    threeCs uThreeCs (
-        .see0(cStuffIf),
-        .see1(cStuff1),
-        .see2(cStuff2),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    threeCs uThreeCs (.see0(cStuffIf), .see1(cStuff1), .see2(cStuff2), .clk(clk), .rst_n(rst_n));
 
     blockBRegs uBlockBRegs (
         .apbReg(apbReg),

--- a/examples/mixed/rtl/blockBRegs.sv
+++ b/examples/mixed/rtl/blockBRegs.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --block=blockBRegs
 // GENERATED_CODE_BEGIN --template=moduleRegs
 module blockBRegs
-    // Generated Import package statement(s)
     import mixedInclude_package::*;
     import mixedBlockC_package::*;
     import mixed_package::*;

--- a/examples/mixed/rtl/blockC.sv
+++ b/examples/mixed/rtl/blockC.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=blockC
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockC
 module blockC
-import mixedBlockC_package::*;
+    import mixedBlockC_package::*;
 (
     rdy_vld_if.dst see,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: blockC

--- a/examples/mixed/rtl/blockC.sv
+++ b/examples/mixed/rtl/blockC.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockC
 module blockC
-// Generated Import package statement(s)
 import mixedBlockC_package::*;
 (
     rdy_vld_if.dst see,

--- a/examples/mixed/rtl/blockD.sv
+++ b/examples/mixed/rtl/blockD.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockD
 module blockD
-// Generated Import package statement(s)
 import mixedInclude_package::*;
 import mixedBlockC_package::*;
 import mixed_package::*;

--- a/examples/mixed/rtl/blockD.sv
+++ b/examples/mixed/rtl/blockD.sv
@@ -1,10 +1,9 @@
 // GENERATED_CODE_PARAM --block=blockD
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockD
 module blockD
-import mixedInclude_package::*;
-import mixedBlockC_package::*;
-import mixed_package::*;
+    import mixedInclude_package::*;
+    import mixedBlockC_package::*;
+    import mixed_package::*;
 (
     rdy_vld_if.src cStuffIf,
     rdy_vld_if.src dee0,
@@ -18,12 +17,14 @@ import mixed_package::*;
     memory_if.dst blockBTable37Bit,
     memory_if.src blockBTable1,
     memory_if.src blockBTableSP,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 // Memory storage for blockBTable37Bit (external listener)

--- a/examples/mixed/rtl/blockF.sv
+++ b/examples/mixed/rtl/blockF.sv
@@ -20,17 +20,8 @@ module blockF
 
     // Memory Interfaces
 
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) test (
-    );
-
-    memory_if #(
-        .data_t(seeSt),
-        .addr_t(bSizeSt)
-    ) test_unused (
-    );
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) test ();
+    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) test_unused ();
 
     // Instances
     // Memory Instances

--- a/examples/mixed/rtl/blockF.sv
+++ b/examples/mixed/rtl/blockF.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: blockF
 module blockF
-// Generated Import package statement(s)
 import mixed_package::*;
 import mixedBlockC_package::*;
 #(

--- a/examples/mixed/rtl/blockF.sv
+++ b/examples/mixed/rtl/blockF.sv
@@ -1,35 +1,48 @@
 // GENERATED_CODE_PARAM --block=blockF
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: blockF
 module blockF
-import mixed_package::*;
-import mixedBlockC_package::*;
+    import mixed_package::*;
+    import mixedBlockC_package::*;
 #(
-    parameter bob,
-    parameter fred
-)
-(
+    parameter int bob,
+    parameter int fred
+) (
     rdy_vld_if.src cStuffIf,
     rdy_vld_if.dst dStuffIf,
     rdy_vld_if.dst dSin,
     rdy_vld_if.src dSout,
     status_if.dst rwD,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
     // Memory Interfaces
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) test();
-    memory_if #(.data_t(seeSt), .addr_t(bSizeSt)) test_unused();
 
-// Instances
-// Memory Instances
-memory_dp #(.DEPTH(bob), .data_t(seeSt)) uTest (
-    .mem_portA (test),
-    .mem_portB (test_unused),
-    .clk (clk)
-);
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) test (
+    );
+
+    memory_if #(
+        .data_t(seeSt),
+        .addr_t(bSizeSt)
+    ) test_unused (
+    );
+
+    // Instances
+    // Memory Instances
+
+    memory_dp #(
+        .DEPTH(bob),
+        .data_t(seeSt)
+    ) uTest (
+        .mem_portA(test),
+        .mem_portB(test_unused),
+        .clk(clk)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/rtl/cpu.sv
+++ b/examples/mixed/rtl/cpu.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: cpu
 module cpu
-// Generated Import package statement(s)
 import mixed_package::*;
 (
     apb_if.src cpu_main,

--- a/examples/mixed/rtl/cpu.sv
+++ b/examples/mixed/rtl/cpu.sv
@@ -1,16 +1,17 @@
 // GENERATED_CODE_PARAM --block=cpu
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: cpu
 module cpu
-import mixed_package::*;
+    import mixed_package::*;
 (
     apb_if.src cpu_main,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
+    // Instances
+
 // GENERATED_CODE_END
 
 endmodule: cpu

--- a/examples/mixed/rtl/mixed.sv
+++ b/examples/mixed/rtl/mixed.sv
@@ -1,55 +1,82 @@
 // GENERATED_CODE_PARAM --block=mixed
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: mixed
 module mixed
-import mixedBlockC_package::*;
-import mixed_package::*;
+    import mixedBlockC_package::*;
+    import mixed_package::*;
 (
     apb_if.dst cpu_main,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
-    req_ack_if #(.data_t(aSt), .rdata_t(aASt)) aStuffIf();
-    rdy_vld_if #(.data_t(seeSt)) cStuffIf();
-    notify_ack_if #() startDone();
-    rdy_vld_if #(.data_t(seeSt)) dupIf();
-    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockA();
-    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockB();
 
-// Instances
-blockA uBlockA (
-    .aStuffIf (aStuffIf),
-    .cStuffIf (cStuffIf),
-    .startDone (startDone),
-    .dupIf (dupIf),
-    .apbReg (apb_uBlockA),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    req_ack_if #(
+        .data_t(aSt),
+        .rdata_t(aASt)
+    ) aStuffIf (
+    );
 
-apbDecode uAPBDecode (
-    .cpu_main (cpu_main),
-    .apb_uBlockA (apb_uBlockA),
-    .apb_uBlockB (apb_uBlockB),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(seeSt)
+    ) cStuffIf (
+    );
 
-blockC uBlockC (
-    .see (cStuffIf),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    notify_ack_if startDone (
+    );
 
-blockB uBlockB (
-    .btod (aStuffIf),
-    .startDone (startDone),
-    .dupIf (dupIf),
-    .apbReg (apb_uBlockB),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    rdy_vld_if #(
+        .data_t(seeSt)
+    ) dupIf (
+    );
+
+    apb_if #(
+        .addr_t(apbAddrSt),
+        .data_t(apbDataSt)
+    ) apb_uBlockA (
+    );
+
+    apb_if #(
+        .addr_t(apbAddrSt),
+        .data_t(apbDataSt)
+    ) apb_uBlockB (
+    );
+
+
+    // Instances
+
+    blockA uBlockA (
+        .aStuffIf(aStuffIf),
+        .cStuffIf(cStuffIf),
+        .startDone(startDone),
+        .dupIf(dupIf),
+        .apbReg(apb_uBlockA),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    apbDecode uAPBDecode (
+        .cpu_main(cpu_main),
+        .apb_uBlockA(apb_uBlockA),
+        .apb_uBlockB(apb_uBlockB),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockC uBlockC (
+        .see(cStuffIf),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockB uBlockB (
+        .btod(aStuffIf),
+        .startDone(startDone),
+        .dupIf(dupIf),
+        .apbReg(apb_uBlockB),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/rtl/mixed.sv
+++ b/examples/mixed/rtl/mixed.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: mixed
 module mixed
-// Generated Import package statement(s)
 import mixedBlockC_package::*;
 import mixed_package::*;
 (

--- a/examples/mixed/rtl/mixed.sv
+++ b/examples/mixed/rtl/mixed.sv
@@ -11,36 +11,12 @@ module mixed
 
     // Interface Instances, needed for between instanced modules inside this module
 
-    req_ack_if #(
-        .data_t(aSt),
-        .rdata_t(aASt)
-    ) aStuffIf (
-    );
-
-    rdy_vld_if #(
-        .data_t(seeSt)
-    ) cStuffIf (
-    );
-
-    notify_ack_if startDone (
-    );
-
-    rdy_vld_if #(
-        .data_t(seeSt)
-    ) dupIf (
-    );
-
-    apb_if #(
-        .addr_t(apbAddrSt),
-        .data_t(apbDataSt)
-    ) apb_uBlockA (
-    );
-
-    apb_if #(
-        .addr_t(apbAddrSt),
-        .data_t(apbDataSt)
-    ) apb_uBlockB (
-    );
+    req_ack_if #(.data_t(aSt), .rdata_t(aASt)) aStuffIf ();
+    rdy_vld_if #(.data_t(seeSt)) cStuffIf ();
+    notify_ack_if startDone ();
+    rdy_vld_if #(.data_t(seeSt)) dupIf ();
+    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockA ();
+    apb_if #(.addr_t(apbAddrSt), .data_t(apbDataSt)) apb_uBlockB ();
 
 
     // Instances
@@ -63,11 +39,7 @@ module mixed
         .rst_n(rst_n)
     );
 
-    blockC uBlockC (
-        .see(cStuffIf),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockC uBlockC (.see(cStuffIf), .clk(clk), .rst_n(rst_n));
 
     blockB uBlockB (
         .btod(aStuffIf),

--- a/examples/mixed/rtl/mixedInclude_package.sv
+++ b/examples/mixed/rtl/mixedInclude_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context mixedInclude.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixedInclude_package;
-// Generated Import package statement(s)
 import mixedNestedInclude_package::*;
 localparam int unsigned BSIZE = 32'h0000_000A;  // The size of B, used for memory wordlines
 localparam int unsigned BSIZE_LOG2 = 32'h0000_0004;  // The size of B, used for memory wordlines log 2

--- a/examples/mixed/rtl/mixed_package.sv
+++ b/examples/mixed/rtl/mixed_package.sv
@@ -1,7 +1,6 @@
 // GENERATED_CODE_PARAM --context mixed.yaml
 // GENERATED_CODE_BEGIN --template=package --fileMapKey=package_sv
 package mixed_package;
-// Generated Import package statement(s)
 import mixedBlockC_package::*;
 import mixedNestedInclude_package::*;
 import mixedInclude_package::*;

--- a/examples/mixed/rtl/threeCs.sv
+++ b/examples/mixed/rtl/threeCs.sv
@@ -2,7 +2,6 @@
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
 //module as defined by block: threeCs
 module threeCs
-// Generated Import package statement(s)
 import mixedBlockC_package::*;
 (
     rdy_vld_if.dst see0,

--- a/examples/mixed/rtl/threeCs.sv
+++ b/examples/mixed/rtl/threeCs.sv
@@ -1,35 +1,36 @@
 // GENERATED_CODE_PARAM --block=threeCs
 // GENERATED_CODE_BEGIN --template=moduleInterfacesInstances
-//module as defined by block: threeCs
 module threeCs
-import mixedBlockC_package::*;
+    import mixedBlockC_package::*;
 (
     rdy_vld_if.dst see0,
     rdy_vld_if.dst see1,
     rdy_vld_if.dst see2,
-    input clk, rst_n
+    input logic clk,
+    input logic rst_n
 );
 
     // Interface Instances, needed for between instanced modules inside this module
 
-// Instances
-blockC uBlockC0 (
-    .see (see0),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    // Instances
 
-blockC uBlockC1 (
-    .see (see1),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    blockC uBlockC0 (
+        .see(see0),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
-blockC uBlockC2 (
-    .see (see2),
-    .clk (clk),
-    .rst_n (rst_n)
-);
+    blockC uBlockC1 (
+        .see(see1),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
+
+    blockC uBlockC2 (
+        .see(see2),
+        .clk(clk),
+        .rst_n(rst_n)
+    );
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/rtl/threeCs.sv
+++ b/examples/mixed/rtl/threeCs.sv
@@ -14,23 +14,9 @@ module threeCs
 
     // Instances
 
-    blockC uBlockC0 (
-        .see(see0),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockC uBlockC1 (
-        .see(see1),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
-
-    blockC uBlockC2 (
-        .see(see2),
-        .clk(clk),
-        .rst_n(rst_n)
-    );
+    blockC uBlockC0 (.see(see0), .clk(clk), .rst_n(rst_n));
+    blockC uBlockC1 (.see(see1), .clk(clk), .rst_n(rst_n));
+    blockC uBlockC2 (.see(see2), .clk(clk), .rst_n(rst_n));
 
 // GENERATED_CODE_END
 

--- a/examples/mixed/verif/vl_wrap/blockA_hdl_sv_wrapper.sv
+++ b/examples/mixed/verif/vl_wrap/blockA_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module blockA_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import mixedInclude_package::*;
     import mixedBlockC_package::*;
     import mixed_package::*;

--- a/examples/mixed/verif/vl_wrap/blockF_variant0_hdl_sv_wrapper.sv
+++ b/examples/mixed/verif/vl_wrap/blockF_variant0_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module blockF_variant0_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import mixed_package::*;
     import mixedBlockC_package::*;
 (

--- a/examples/mixed/verif/vl_wrap/blockF_variant1_hdl_sv_wrapper.sv
+++ b/examples/mixed/verif/vl_wrap/blockF_variant1_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module blockF_variant1_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import mixed_package::*;
     import mixedBlockC_package::*;
 (

--- a/examples/mixed/verif/vl_wrap/mixed_hdl_sv_wrapper.sv
+++ b/examples/mixed/verif/vl_wrap/mixed_hdl_sv_wrapper.sv
@@ -5,7 +5,6 @@
 // GENERATED_CODE_BEGIN --template=module_hdl_sv_wrapper
 
 module mixed_hdl_sv_wrapper
-    // Generated Import package statement(s)
     import mixedBlockC_package::*;
     import mixed_package::*;
 (

--- a/pysrc/intf_gen_utils.py
+++ b/pysrc/intf_gen_utils.py
@@ -5,14 +5,15 @@
 LEGACY_COMPAT_MODE = False
 
 from pysrc.arch2codeHelper import printError
+import pysrc.sv_model as svm
 
 def get_set_intf_types(ifType, block_data):
     """Get set of interface names, resolving any type aliases
-    
+
     Args:
         ifType: Interface type or collection of interface types
         block_data: Block data dict containing interface_type_mappings
-    
+
     Returns:
         Set of canonical interface type names
     """
@@ -20,11 +21,11 @@ def get_set_intf_types(ifType, block_data):
 
 def get_intf_type(ifType, block_data):
     """Resolve interface type alias to canonical interface type
-    
+
     Args:
         ifType: Interface type (may be an alias like 'reg_ro')
         block_data: Block data dict containing interface_type_mappings
-    
+
     Returns:
         Canonical interface type (e.g., 'reg_ro' -> 'status')
     """
@@ -158,6 +159,22 @@ def sv_gen_ports(data, prj, indent, block_data):
     out.append(f"{indent}input clk, rst_n")
     out.append(");\n")
     return out
+
+def sv_gen_ports_svm(data, prj, indent, block_data):
+    port_objects = []
+    for sourceType in data['ports']:
+        for port, port_data in data['ports'][sourceType].items():
+            connectionData = port_data.get('connection', {})
+            intf_data = get_intf_data(connectionData, prj)
+            intf_type = get_intf_type(intf_data['interfaceType'], block_data)
+            port_objects.append(
+                svm.InterfacePortDecl(
+                    name=port_data['name'],
+                    interface_name=intf_type + '_if',
+                    modport_name=port_data['direction']
+                )
+            )
+    return port_objects
 
 def sc_connect_channels(data, indent, block_data):
     out = []
@@ -399,11 +416,11 @@ def get_sorted_memories(data):
 
 def get_intf_defs(intf_type, block_data):
     """Get interface definition for given interface type
-    
+
     Args:
         intf_type: Interface type name
         block_data: Block data dict containing interface_defs
-    
+
     Returns:
         Interface definition dict or None if not found
     """

--- a/pysrc/intf_gen_utils.py
+++ b/pysrc/intf_gen_utils.py
@@ -160,7 +160,7 @@ def sv_gen_ports(data, prj, indent, block_data):
     out.append(");\n")
     return out
 
-def sv_gen_ports_svm(data, prj, indent, block_data):
+def sv_gen_ports_svm(data, prj, block_data):
     port_objects = []
     for sourceType in data['ports']:
         for port, port_data in data['ports'][sourceType].items():

--- a/pysrc/sv_model.py
+++ b/pysrc/sv_model.py
@@ -1577,6 +1577,7 @@ class ModuleDecl(SvNode):
     ports: List[ModulePortItem] = []
     body: List[ModuleBodyItem] = []
     end_label: bool = True  # emit `: name` after endmodule per LRM §A.1.2
+    emit_end: bool = True
 
     def render(self, indent: int = 0) -> str:
         pad = _ind(indent)
@@ -1649,10 +1650,12 @@ class ModuleDecl(SvNode):
         # ── endmodule [ : identifier ] ────────────────────────────────────────
         if self.body:
             lines.append("")
-        footer = f"{pad}endmodule"
-        if self.end_label:
-            footer += f" : {self.name}"
-        lines.append(footer)
+
+        if self.emit_end:
+            footer = f"{pad}endmodule"
+            if self.end_label:
+                footer += f" : {self.name}"
+                lines.append(footer)
 
         return "\n".join(lines)
 

--- a/pysrc/sv_model.py
+++ b/pysrc/sv_model.py
@@ -1,0 +1,1849 @@
+"""
+sv_model.py — SystemVerilog code generation models
+
+Mapped from IEEE 1800-2017 Annex A BNF grammar.
+Scope: interface declarations, module declarations, and hierarchical
+instantiations (modules and interfaces).
+
+Direction of use: populate models from a database / YAML, call .render()
+to emit LRM-compliant SystemVerilog source text.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Callable, List, Literal, Optional, Union
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
+
+# ─── Rendering helpers ────────────────────────────────────────────────────────
+
+_INDENT = "    "  # 4-space per LRM examples
+
+
+def _ind(n: int) -> str:
+    return _INDENT * n
+
+
+def _inline_comment(text: Optional[str]) -> str:
+    return f"  // {text}" if text else ""
+
+
+def _with_sep(rendered: str, sep: str) -> str:
+    """Place ``sep`` before any inline comment so commas precede ``//``."""
+    marker = "  // "
+    if sep and marker in rendered:
+        idx = rendered.index(marker)
+        return rendered[:idx] + sep + rendered[idx:]
+    return rendered + sep
+
+
+def _begin_end(
+    header: str,
+    body: str,
+    label: Optional[str],
+    indent: int,
+    comment: Optional[str] = None,
+) -> str:
+    """
+    Render a ``begin [ : label ] … end [ : label ]`` block.
+
+    The *header* is the keyword line prefix (e.g. ``"always_ff @(posedge clk)"``).
+    The *body* text is re-indented to ``indent + 1``; blank lines are preserved
+    without trailing whitespace.  The optional ``comment`` is placed inline on
+    the opening keyword line.
+    """
+    pad = _ind(indent)
+    inner = _ind(indent + 1)
+    label_sfx = f" : {label}" if label else ""
+    lines = [f"{pad}{header} begin{label_sfx}" + _inline_comment(comment)]
+    for line in body.splitlines():
+        stripped = line.rstrip()
+        lines.append(f"{inner}{stripped}" if stripped else "")
+    lines.append(f"{pad}end{label_sfx}")
+    return "\n".join(lines)
+
+
+def _begin_end_items(
+    header: str,
+    body: List[Any],
+    label: Optional[str],
+    indent: int,
+    comment: Optional[str] = None,
+) -> str:
+    """
+    Same as ``_begin_end``, but *body* is a list of ``SvNode`` instances rendered
+    at ``indent + 1`` (each node's ``render`` output is appended line-wise).
+    """
+    pad = _ind(indent)
+    inner = indent + 1
+    label_sfx = f" : {label}" if label else ""
+    lines = [f"{pad}{header} begin{label_sfx}" + _inline_comment(comment)]
+    for item in body:
+        for line in item.render(inner).splitlines():
+            stripped = line.rstrip()
+            lines.append(stripped if stripped else "")
+    lines.append(f"{pad}end{label_sfx}")
+    return "\n".join(lines)
+
+
+# ─── Base class ───────────────────────────────────────────────────────────────
+
+
+class SvNode(BaseModel):
+    """
+    Base for every AST node.
+
+    - ``comment``: optional inline ``// comment`` appended to the node's
+      primary output line.
+    - ``render_engine``: optional custom render callable invoked *instead of*
+      the built-in renderer.  Signature::
+
+          def my_renderer(node: SvNode, indent: int) -> str: ...
+
+      The callable receives the fully-populated node object (``node``) so it
+      has access to every field as context, and the current indentation level
+      (``indent``).  Set this field programmatically; it is excluded from
+      JSON/YAML serialisation.
+    - ``render(indent)`` emits the BNF construct as LRM-formatted text.
+    """
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    comment: Optional[str] = Field(
+        default=None,
+        description="Inline // comment appended to this node's primary line.",
+    )
+    render_engine: Optional[Callable[["SvNode", int], str]] = Field(
+        default=None,
+        exclude=True,
+        repr=False,
+        description=(
+            "Optional custom render callable invoked instead of the built-in "
+            "renderer.  Signature: ``(node: SvNode, indent: int) -> str``. "
+            "Set programmatically; excluded from serialisation."
+        ),
+    )
+
+    @field_validator("render_engine", mode="before")
+    @classmethod
+    def _validate_render_engine(cls, v: object) -> object:
+        if v is None or callable(v):
+            return v
+        raise ValueError(
+            "render_engine must be a callable with signature "
+            "(node: SvNode, indent: int) -> str, or None"
+        )
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """
+        Wrap every subclass ``render`` implementation so that when
+        ``render_engine`` is set on an instance it is called transparently
+        in place of the built-in method — no per-subclass changes required.
+        """
+        super().__init_subclass__(**kwargs)
+        original = cls.__dict__.get("render")
+        if original is not None:
+            def _make_wrapped(f: Any) -> Any:
+                def _wrapped(self: "SvNode", indent: int = 0) -> str:
+                    if self.render_engine is not None:
+                        return self.render_engine(self, indent)
+                    return f(self, indent)
+                _wrapped.__doc__ = f.__doc__
+                _wrapped.__name__ = f.__name__
+                _wrapped.__qualname__ = f.__qualname__
+                return _wrapped
+            cls.render = _make_wrapped(original)  # type: ignore[method-assign]
+
+    def render(self, indent: int = 0) -> str:  # pragma: no cover
+        if self.render_engine is not None:
+            return self.render_engine(self, indent)
+        raise NotImplementedError(type(self).__name__)
+
+
+# ─── Dimensions (A.2.5) ───────────────────────────────────────────────────────
+
+
+class PackedDim(SvNode):
+    """
+    packed_dimension (A.2.5) ::= [ msb : lsb ]
+
+    Example: ``[DATA_WIDTH-1:0]``
+    """
+
+    msb: str
+    lsb: str = "0"
+
+    def render(self, indent: int = 0) -> str:
+        return f"[{self.msb}:{self.lsb}]"
+
+
+class UnpackedDim(SvNode):
+    """
+    unpacked_dimension (A.2.5) ::= [ msb : lsb ] | [ size ]
+
+    Use ``size`` as a shorthand for ``[size]`` (e.g. array lengths).
+    """
+
+    msb: Optional[str] = None
+    lsb: Optional[str] = None
+    size: Optional[str] = None
+
+    def render(self, indent: int = 0) -> str:
+        if self.size is not None:
+            return f"[{self.size}]"
+        return f"[{self.msb}:{self.lsb}]"
+
+
+# ─── Header parameters (A.2.1.1) ─────────────────────────────────────────────
+
+
+class ParamDecl(SvNode):
+    """
+    parameter_declaration (A.2.1.1):
+        ``parameter data_type_or_implicit list_of_param_assignments``
+
+    Used inside the module ``#( … )`` parameter port list.
+    """
+
+    name: str
+    data_type: str = "int"
+    default: Optional[str] = None
+
+    def render(self, indent: int = 0) -> str:
+        base = f"parameter {self.data_type} {self.name}"
+        if self.default is not None:
+            base += f" = {self.default}"
+        return base + _inline_comment(self.comment)
+
+
+# ─── Port declarations (A.1.3 / A.2.1.3) ─────────────────────────────────────
+
+Direction = Literal["input", "output", "inout", "ref"]
+
+# Net types (§6.5) — synthesised from multiple drivers; cannot hold state.
+# A signal declared with one of these types is a *net* and may NOT be connected
+# to a ``ref`` port (§23.2.2.3).
+NetType = Literal[
+    "wire", "tri", "wand", "wor", "triand", "trior",
+    "tri0", "tri1", "supply0", "supply1", "uwire",
+    # Variable / data types (§6.2, §6.4) — hold state; legal for ``ref`` ports.
+    "logic", "reg", "bit",
+    "byte", "shortint", "int", "longint", "integer", "time",
+    "real", "shortreal", "realtime",
+]
+
+# Private sets used by validate_instance_connections for §23.2.2.3 checks.
+_NET_TYPES: frozenset[str] = frozenset({
+    "wire", "tri", "wand", "wor", "triand", "trior",
+    "tri0", "tri1", "supply0", "supply1", "uwire",
+})
+_VARIABLE_TYPES: frozenset[str] = frozenset({
+    "logic", "reg", "bit",
+    "byte", "shortint", "int", "longint", "integer", "time",
+    "real", "shortreal", "realtime",
+})
+
+# Signing modifier (§6.2.2) — placed between the type keyword and packed dims:
+#   ``logic signed [7:0] data``
+Signing = Literal["signed", "unsigned"]
+
+
+class PortDecl(SvNode):
+    """
+    ansi_port_declaration (A.1.3):
+        ``[ port_direction ] [ net_type ] [ signing ] { packed_dim } identifier { unpacked_dim }``
+
+    ``net_type=None`` omits the type keyword (inherits from previous port or
+    uses the module default net type per LRM §23.2.2.3).
+
+    ``signing`` inserts ``signed`` / ``unsigned`` between the type keyword and
+    the first packed dimension (§6.2.2).  Unsigned is the default for all net
+    types and for ``logic``/``bit``; ``signed`` is the default for ``int``,
+    ``shortint``, ``longint``, ``byte``, ``integer`` — omit the field when the
+    LRM default is intended.
+
+    ``ref`` ports must connect to variables, not nets (§23.2.2.3).
+
+    **Unpacked array ports (§23.3.3.5)**
+
+    One or more ``unpacked_dims`` make this an *unpacked array port*.  The
+    packed dimensions (if any) describe the element type; the unpacked
+    dimensions describe how many elements there are::
+
+        input logic [7:0] data [0:3]   # 4-element array of byte-wide ports
+            ^^^^^^^^^^^^ packed        ^^^^^  unpacked
+
+    When such a port is connected in an array-of-instances context, the LRM
+    distributes array elements across instances automatically (§23.3.3.5).
+    Use ``IndexedSlice`` in the connecting ``PortConn.expression`` when an
+    explicit per-element selection is required (e.g. ``data_arr[i][7:0]``).
+    """
+
+    kind: Literal["port"] = "port"
+    direction: Direction
+    net_type: Optional[NetType] = "logic"
+    signing: Optional[Signing] = None
+    packed_dims: List[PackedDim] = []
+    name: str
+    unpacked_dims: List[UnpackedDim] = []
+    default: Optional[str] = None
+
+    def render(self, indent: int = 0) -> str:
+        parts: list[str] = [self.direction]
+        if self.net_type:
+            parts.append(self.net_type)
+        if self.signing:
+            parts.append(self.signing)
+        parts.extend(d.render() for d in self.packed_dims)
+        parts.append(self.name)
+        parts.extend(d.render() for d in self.unpacked_dims)
+        base = " ".join(parts)
+        if self.default is not None:
+            base += f" = {self.default}"
+        return base + _inline_comment(self.comment)
+
+
+# ─── Modports (§25.5) / interface-typed module ports ───────────────────────────
+
+
+class ModportPortDecl(SvNode):
+    """
+    One port direction entry inside a ``modport`` declaration.
+
+    Example: ``output req``
+    """
+
+    direction: Direction
+    name: str
+
+    def render(self, indent: int = 0) -> str:
+        return f"{self.direction} {self.name}"
+
+
+class ModportDecl(SvNode):
+    """
+    modport_declaration (§25.5):
+
+        ``modport modport_identifier ( { modport_ports_declaration } ) ;``
+
+    Example: ``modport master_mp(output req, input ack);``
+    """
+
+    kind: Literal["modport"] = "modport"
+    name: str
+    ports: List[ModportPortDecl]
+
+    def render(self, indent: int = 0) -> str:
+        inner = ", ".join(p.render() for p in self.ports)
+        return (
+            f"{_ind(indent)}modport {self.name}({inner});"
+            + _inline_comment(self.comment)
+        )
+
+
+class InterfacePortDecl(SvNode):
+    """
+    A module port whose type is an interface, optionally restricted by modport.
+
+    Examples::
+
+        my_if.master_mp bus
+        my_if bus
+        my_if.slave_mp chan [0:3]
+    """
+
+    kind: Literal["iface_port"] = "iface_port"
+    interface_name: str
+    modport_name: Optional[str] = None
+    name: str
+    unpacked_dims: List[UnpackedDim] = []
+
+    def render(self, indent: int = 0) -> str:
+        if self.modport_name:
+            base = f"{self.interface_name}.{self.modport_name} {self.name}"
+        else:
+            base = f"{self.interface_name} {self.name}"
+        base += "".join(d.render() for d in self.unpacked_dims)
+        return base + _inline_comment(self.comment)
+
+
+# Plain union (no ``discriminator``): YAML/JSON inputs often omit ``kind`` on
+# ports; ``PortDecl`` supplies ``kind="port"`` by default.  ``InterfacePortDecl``
+# is tried when ``PortDecl`` fails (e.g. ``interface_name`` present).
+ModulePortItem = Union[PortDecl, InterfacePortDecl]
+
+
+# ─── Module body items ────────────────────────────────────────────────────────
+#
+# Each concrete body-item class carries a ``kind`` Literal field used as the
+# Pydantic discriminator so that YAML/JSON round-trips work without ambiguity.
+
+
+class LocalparamDecl(SvNode):
+    """
+    local_parameter_declaration (A.2.1.1):
+        ``localparam data_type_or_implicit list_of_param_assignments ;``
+    """
+
+    kind: Literal["localparam"] = "localparam"
+    data_type: str = "int"
+    name: str
+    value: str
+
+    def render(self, indent: int = 0) -> str:
+        base = f"{_ind(indent)}localparam {self.data_type} {self.name} = {self.value};"
+        return base + _inline_comment(self.comment)
+
+
+class NetDecl(SvNode):
+    """
+    net_declaration / data_declaration (A.2.1.3):
+        ``net_type [ signing ] { packed_dim } identifier { unpacked_dim } [ = initial ] ;``
+
+    Covers all net types (``wire``, ``tri``, …) and variable/data types
+    (``logic``, ``reg``, ``bit``, integer types, …) as enumerated in §6.2–6.5.
+
+    ``signing`` inserts ``signed`` / ``unsigned`` between the type keyword and
+    the first packed dimension (§6.2.2).
+    """
+
+    kind: Literal["net"] = "net"
+    net_type: NetType = "logic"
+    signing: Optional[Signing] = None
+    packed_dims: List[PackedDim] = []
+    name: str
+    unpacked_dims: List[UnpackedDim] = []
+    initial_value: Optional[str] = None
+
+    def render(self, indent: int = 0) -> str:
+        parts: list[str] = [self.net_type]
+        if self.signing:
+            parts.append(self.signing)
+        parts.extend(d.render() for d in self.packed_dims)
+        parts.append(self.name)
+        parts.extend(d.render() for d in self.unpacked_dims)
+        base = f"{_ind(indent)}{' '.join(parts)}"
+        if self.initial_value is not None:
+            base += f" = {self.initial_value}"
+        return base + ";" + _inline_comment(self.comment)
+
+
+class TypedVarDecl(SvNode):
+    """
+    Data declaration with a free-form type expression (user-defined type,
+    ``parameter type`` name, typedef, etc.).
+
+    Used when ``NetDecl.net_type`` (a closed ``Literal``) cannot express the
+    type, e.g. ``DATA_T data_in;`` inside a type-parameterized interface.
+
+    Example: ``my_struct_t payload [3:0];``
+    """
+
+    kind: Literal["typed_var"] = "typed_var"
+    user_type: str
+    name: str
+    unpacked_dims: List[UnpackedDim] = []
+
+    def render(self, indent: int = 0) -> str:
+        parts: list[str] = [self.user_type, self.name]
+        parts.extend(d.render() for d in self.unpacked_dims)
+        base = f"{_ind(indent)}{' '.join(parts)};"
+        return base + _inline_comment(self.comment)
+
+
+# ─── Module instantiation (A.4.1) ─────────────────────────────────────────────
+
+
+class ParamConn(SvNode):
+    """
+    named_parameter_assignment (A.4.1):
+        ``. parameter_identifier ( param_expression )``
+    """
+
+    param: str
+    value: str
+
+    def render(self, indent: int = 0) -> str:
+        return f"{_ind(indent)}.{self.param}({self.value})" + _inline_comment(self.comment)
+
+
+class SvExpr(BaseModel):
+    """
+    Base for inline expression nodes used inside port/parameter connections.
+
+    Intentionally does **not** carry a ``comment`` field — expressions are
+    always inlined into a larger construct and cannot hold standalone comments.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    def render(self) -> str:  # pragma: no cover
+        raise NotImplementedError(type(self).__name__)
+
+
+# ─── Port-connection expression types (A.4.1 / A.8) ──────────────────────────
+#
+# These replace the former ``Optional[str]`` in ``PortConn`` so that every
+# connected value refers to a structurally declared object in the hierarchy
+# (a net/port by name, a bit-select or part-select of one, or a concatenation
+# of such references).  Raw constant strings are intentionally excluded — use
+# ``NetDecl`` / ``PortDecl`` names, not magic literals.
+#
+# Recursive self-reference in ``Concatenation`` requires ``model_rebuild()``
+# at the bottom of this file.
+
+
+class SignalRef(SvExpr):
+    """
+    Simple reference to a declared net, variable, or port by name.
+
+    Example: ``clk``, ``data_in``, ``MY_PARAM``
+    """
+
+    kind: Literal["signal"] = "signal"
+    name: str
+
+    def render(self) -> str:
+        return self.name
+
+
+class BitSelect(SvExpr):
+    """
+    Single-bit select: ``name[index]``
+
+    ``index`` is a constant expression string (e.g. ``"3"`` or ``"i"``).
+    """
+
+    kind: Literal["bit_select"] = "bit_select"
+    name: str
+    index: str
+
+    def render(self) -> str:
+        return f"{self.name}[{self.index}]"
+
+
+class PartSelect(SvExpr):
+    """
+    Part-select: ``name[msb:lsb]``
+
+    Example: ``data[7:0]``
+    """
+
+    kind: Literal["part_select"] = "part_select"
+    name: str
+    msb: str
+    lsb: str
+
+    def render(self) -> str:
+        return f"{self.name}[{self.msb}:{self.lsb}]"
+
+
+class IndexedSlice(SvExpr):
+    """
+    Two-level select: ``name[index][msb:lsb]``
+
+    Selects one element of an unpacked array and then a packed range within
+    that element.  This is the canonical expression form when connecting a
+    specific element of an array port to an instance port in an array-of-
+    instances context (§23.3.3.5).
+
+    Example: ``data_arr[2][7:0]`` — element 2, bits 7 down to 0.
+
+    For a plain unpacked-element select without a further packed range, use
+    ``BitSelect`` (``name[index]``).
+    """
+
+    kind: Literal["indexed_slice"] = "indexed_slice"
+    name: str
+    index: str   # constant expression for the unpacked dimension
+    msb: str
+    lsb: str
+
+    def render(self) -> str:
+        return f"{self.name}[{self.index}][{self.msb}:{self.lsb}]"
+
+
+class ConstantExpr(SvExpr):
+    """
+    A literal constant value emitted verbatim.
+
+    Use for numeric literals (``1'b0``, ``8'hFF``), parameter expressions
+    (``WIDTH-1``), or any other constant that is not a declared signal name.
+
+    Examples::
+
+        ConstantExpr(value="1'b0")      → ``1'b0``
+        ConstantExpr(value="8'hFF")     → ``8'hFF``
+    """
+
+    kind: Literal["constant"] = "constant"
+    value: str
+
+    def render(self) -> str:
+        return self.value
+
+
+class VerbatimExpr(SvExpr):
+    """
+    Arbitrary expression text (casts, operators, function calls, etc.).
+
+    Use in ``AssignStatement.rhs`` (or ``lvalue``) when the value cannot be
+    built from ``SignalRef``, ``Concatenation``, and other structured nodes.
+    The string is emitted unchanged—reserve for expressions that are valid
+    SystemVerilog on the corresponding side of ``=``.
+
+    In YAML/JSON you may give ``AssignStatement.rhs`` as a plain string; it
+    is normalized to ``verbatim`` automatically.
+
+    Prefer structured ``PortConnExpr`` where possible so connectivity checks
+    and tooling can resolve signal names.
+    """
+
+    kind: Literal["verbatim"] = "verbatim"
+    text: str
+
+    def render(self) -> str:
+        return self.text
+
+
+class InterfaceRef(SvExpr):
+    """
+    Reference to an interface instance (or interface port) by identifier.
+
+    Example: ``bus_if`` — used on the RHS of ``.port(expr)`` for interface
+    connections and for distributing whole unpacked arrays of interfaces
+    (§23.3.3.5).
+    """
+
+    kind: Literal["iface_ref"] = "iface_ref"
+    name: str
+
+    def render(self) -> str:
+        return self.name
+
+
+class InterfaceIndexedRef(SvExpr):
+    """
+    Single element of an unpacked array of interface instances.
+
+    Example: ``bus_if[2]`` or ``bus_if[i]``
+    """
+
+    kind: Literal["iface_indexed"] = "iface_indexed"
+    name: str
+    index: str
+
+    def render(self) -> str:
+        return f"{self.name}[{self.index}]"
+
+
+class Concatenation(SvExpr):
+    """
+    Concatenation: ``{ part0, part1, … }``
+
+    Parts are themselves ``PortConnExpr`` values, enabling nested
+    concatenations such as ``{a, b[3:0], {c, d}}``.
+
+    Because ``PortConnExpr`` is a forward reference, call
+    ``Concatenation.model_rebuild()`` after ``PortConnExpr`` is defined.
+    """
+
+    kind: Literal["concat"] = "concat"
+    parts: List[PortConnExpr]  # type: ignore[name-defined]  # forward ref
+
+    def render(self) -> str:
+        return "{" + ", ".join(p.render() for p in self.parts) + "}"
+
+
+# Discriminated union — Pydantic selects the right class from ``kind``.
+# ``IndexedSlice`` must appear before ``PartSelect`` in the union so that the
+# discriminator (``kind``) is unambiguous even though both carry ``msb``/``lsb``.
+# ``ConstantExpr`` covers literal values (``1'b0``, ``8'hFF``, …) that are not
+# declared signal names; ``VerbatimExpr`` is for arbitrary expression text.
+# Both are valid in assign RHS/LHS; for port connections prefer structured refs.
+PortConnExpr = Annotated[
+    Union[
+        SignalRef,
+        BitSelect,
+        PartSelect,
+        IndexedSlice,
+        Concatenation,
+        ConstantExpr,
+        VerbatimExpr,
+        InterfaceRef,
+        InterfaceIndexedRef,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+class PortConn(SvNode):
+    """
+    named_port_connection (A.4.1):
+        ``. port_identifier [ ( [ expression ] ) ]``
+
+    ``expression=None`` produces an unconnected port: ``.port()``.
+
+    The ``expression`` field accepts only typed connection objects
+    (``SignalRef``, ``BitSelect``, ``PartSelect``, ``Concatenation``) rather
+    than a bare string, so that every connected value can be traced back to a
+    declared object in the hierarchy.
+    """
+
+    port: str
+    expression: Optional[PortConnExpr] = None
+
+    def render(self, indent: int = 0) -> str:
+        expr = "" if self.expression is None else self.expression.render()
+        return f"{_ind(indent)}.{self.port}({expr})" + _inline_comment(self.comment)
+
+
+class ModuleInst(SvNode):
+    """
+    module_instantiation (A.4.1):
+        ``module_identifier [ #( list_of_parameter_assignments ) ]``
+        ``name_of_instance ( [ list_of_port_connections ] ) ;``
+
+    ``name_of_instance`` is defined in A.4.1 as::
+
+        instance_identifier { unpacked_dimension }
+
+    Supplying ``instance_dims`` creates an **array of instances** (§23.3.3.5).
+    Each unpacked dimension adds one axis to the instance array::
+
+        logic_cell u_cells [7:0] ( .a(a_bus), .y(y_bus) );
+        // → 8 instances, LRM distributes port connections across the array
+
+    Connection distribution rules (§23.3.3.5):
+
+    - A port of width W connected by an expression of width W is *replicated*
+      to every instance in the array.
+    - A port of width W connected by an expression of width N×W (where N is
+      the total number of instances) is *distributed* — each instance receives
+      its own W-bit slice.
+    - Unpacked-array signals may be connected directly; the LRM assigns
+      element ``[i]`` of the signal to instance ``[i]``.
+
+    Use ``IndexedSlice`` in ``PortConn.expression`` when you need to connect
+    a specific element-plus-range (``sig[i][msb:lsb]``) explicitly.
+
+    The ``comment`` field is rendered on the closing ``);`` line.
+    """
+
+    kind: Literal["inst"] = "inst"
+    module_name: str
+    instance_name: str
+    instance_dims: List[UnpackedDim] = []
+    parameters: List[ParamConn] = []
+    ports: List[PortConn] = []
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        lines: list[str] = []
+
+        # ── name_of_instance ::= instance_identifier { unpacked_dimension } ──
+        inst_label = self.instance_name
+        if self.instance_dims:
+            inst_label += " " + " ".join(d.render() for d in self.instance_dims)
+
+        # ── type + optional #( parameter_value_assignment ) ──────────────────
+        if self.parameters:
+            lines.append(f"{pad}{self.module_name} #(")
+            for i, p in enumerate(self.parameters):
+                sep = "," if i < len(self.parameters) - 1 else ""
+                lines.append(_with_sep(p.render(indent + 1), sep))
+            lines.append(f"{pad}) {inst_label} (")
+        else:
+            lines.append(f"{pad}{self.module_name} {inst_label} (")
+
+        # ── list_of_port_connections ──────────────────────────────────────────
+        for i, p in enumerate(self.ports):
+            sep = "," if i < len(self.ports) - 1 else ""
+            lines.append(_with_sep(p.render(indent + 1), sep))
+
+        lines.append(f"{pad});" + _inline_comment(self.comment))
+        return "\n".join(lines)
+
+
+class InterfaceInst(SvNode):
+    """
+    interface_instantiation (§25.3):
+
+        ``interface_identifier [ #( parameter_assignments ) ]``
+        ``instance_identifier { unpacked_dimension } ( [ port_connections ] ) ;``
+
+    Syntax mirrors ``ModuleInst``; binds the interface's own ports (e.g. clk).
+    """
+
+    kind: Literal["iface_inst"] = "iface_inst"
+    interface_name: str
+    instance_name: str
+    instance_dims: List[UnpackedDim] = []
+    parameters: List[ParamConn] = []
+    ports: List[PortConn] = []
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        lines: list[str] = []
+
+        inst_label = self.instance_name
+        if self.instance_dims:
+            inst_label += " " + " ".join(d.render() for d in self.instance_dims)
+
+        if self.parameters:
+            lines.append(f"{pad}{self.interface_name} #(")
+            for i, p in enumerate(self.parameters):
+                sep = "," if i < len(self.parameters) - 1 else ""
+                lines.append(_with_sep(p.render(indent + 1), sep))
+            lines.append(f"{pad}) {inst_label} (")
+        else:
+            lines.append(f"{pad}{self.interface_name} {inst_label} (")
+
+        for i, p in enumerate(self.ports):
+            sep = "," if i < len(self.ports) - 1 else ""
+            lines.append(_with_sep(p.render(indent + 1), sep))
+
+        lines.append(f"{pad});" + _inline_comment(self.comment))
+        return "\n".join(lines)
+
+
+# ─── Escape hatches ───────────────────────────────────────────────────────────
+
+
+class RawStatement(SvNode):
+    """
+    Verbatim text block.  Use for constructs not yet modelled (always blocks,
+    assign statements, assertions, …).  Each line is re-indented to ``indent``.
+    """
+
+    kind: Literal["raw"] = "raw"
+    text: str
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        lines = [pad + line for line in self.text.splitlines()]
+        return "\n".join(lines) + _inline_comment(self.comment)
+
+
+def _coerce_procedural_body(value: object) -> object:
+    """Allow a single multi-line string (YAML / legacy) as one ``RawStatement``."""
+    if isinstance(value, str):
+        return [RawStatement(text=value)]
+    return value
+
+
+class CommentBlock(SvNode):
+    """
+    A standalone comment line or block.
+
+    ``block=False`` (default): emits one ``// …`` line per input line.
+    ``block=True``: emits a single ``/* … */`` block comment.
+    """
+
+    kind: Literal["comment_block"] = "comment_block"
+    text: str
+    block: bool = False
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        if self.block:
+            return f"{pad}/* {self.text} */"
+        return "\n".join(f"{pad}// {line}" for line in self.text.splitlines())
+
+
+# ─── Sensitivity list event (A.6.7) ───────────────────────────────────────────
+
+
+class SensitivityEvent(BaseModel):
+    """
+    One event inside an event_control sensitivity list (A.6.7):
+
+    .. code-block:: bnf
+
+        event_expression ::=
+            [ edge_identifier ] expression
+            | event_expression or event_expression
+
+        edge_identifier ::= posedge | negedge | edge
+
+    Set ``edge=None`` for a level-sensitive (combinational) entry; the signal
+    name is emitted without an edge qualifier.
+
+    Examples::
+
+        SensitivityEvent(edge="posedge", signal="clk")   → ``posedge clk``
+        SensitivityEvent(signal="rst_n")                 → ``rst_n``
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    edge: Optional[Literal["posedge", "negedge", "edge"]] = None
+    signal: str
+
+    def render(self) -> str:
+        return f"{self.edge} {self.signal}" if self.edge else self.signal
+
+
+# ─── Continuous assignment (A.6.1) ────────────────────────────────────────────
+
+
+class AssignStatement(SvNode):
+    """
+    continuous_assign (A.6.1):
+
+    .. code-block:: bnf
+
+        continuous_assign ::=
+            assign [ drive_strength ] [ delay3 ] list_of_net_assignments ;
+
+        net_assignment ::= net_lvalue = expression
+
+    ``lvalue`` is the assign target; ``rhs`` is the right-hand side. Either
+    field uses structured ``PortConnExpr`` nodes, or ``rhs`` may be a plain
+    string in the input (coerced to ``VerbatimExpr``) for casts and operators.
+
+    ``delay`` is an optional delay value emitted as ``#delay`` (e.g. ``"1"``).
+
+    Examples::
+
+        assign full = fifo_full;
+        assign #2 data_out = pipe_q;
+    """
+
+    kind: Literal["assign"] = "assign"
+    lvalue: PortConnExpr
+    rhs: PortConnExpr
+    delay: Optional[str] = None
+
+    @field_validator("rhs", mode="before")
+    @classmethod
+    def _rhs_coerce_str(cls, v: object) -> object:
+        if isinstance(v, str):
+            return {"kind": "verbatim", "text": v}
+        return v
+
+    @field_validator("lvalue", mode="before")
+    @classmethod
+    def _lvalue_coerce_str(cls, v: object) -> object:
+        if isinstance(v, str):
+            return {"kind": "verbatim", "text": v}
+        return v
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        delay_part = f" #{self.delay}" if self.delay else ""
+        base = f"{pad}assign{delay_part} {self.lvalue.render()} = {self.rhs.render()};"
+        return base + _inline_comment(self.comment)
+
+
+# ─── Procedural blocks (A.6.4) ────────────────────────────────────────────────
+
+
+class AlwaysComb(SvNode):
+    """
+    always_construct (A.6.4) — combinational process:
+
+    .. code-block:: bnf
+
+        always_construct ::= always_comb seq_block
+
+    The simulator automatically infers the sensitivity list from the ``body``
+    nodes; no explicit ``@(…)`` clause is emitted.
+
+    The ``body`` field is a list of procedural nodes (``RawStatement``,
+    ``CommentBlock``, nested ``always_*`` / ``initial`` / ``final`` blocks,
+    etc.).  A single multi-line string is still accepted at validation time
+    and coerced to one ``RawStatement``.
+    """
+
+    kind: Literal["always_comb"] = "always_comb"
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        return _begin_end_items(
+            "always_comb", self.body, self.label, indent, self.comment
+        )
+
+
+class AlwaysLatch(SvNode):
+    """
+    always_construct (A.6.4) — latch-inference process:
+
+    .. code-block:: bnf
+
+        always_construct ::= always_latch seq_block
+
+    Use when the intent is to infer a level-sensitive latch.  Synthesis tools
+    warn if the body does not imply a latch.
+
+    ``body`` uses the same ``ProceduralBodyItem`` list shape as ``AlwaysComb``
+    (see that class).
+    """
+
+    kind: Literal["always_latch"] = "always_latch"
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        return _begin_end_items(
+            "always_latch", self.body, self.label, indent, self.comment
+        )
+
+
+class AlwaysFf(SvNode):
+    """
+    always_construct (A.6.4) — registered / clocked process:
+
+    .. code-block:: bnf
+
+        always_construct ::= always_ff clocking_event seq_block
+
+        clocking_event ::= @ ( event_expression )
+        event_expression ::=
+            [ edge_identifier ] expression
+            | event_expression or event_expression
+
+    The ``sensitivity`` list is rendered as a comma/or-separated event
+    expression, e.g.::
+
+        sensitivity:
+          - edge: posedge
+            signal: clk
+          - edge: negedge
+            signal: rst_n
+        →  always_ff @(posedge clk or negedge rst_n)
+
+    Synthesis tools enforce that every assignment in the body is a
+    non-blocking (``<=``) assignment.
+    """
+
+    kind: Literal["always_ff"] = "always_ff"
+    sensitivity: List[SensitivityEvent]
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        sens = " or ".join(e.render() for e in self.sensitivity)
+        return _begin_end_items(
+            f"always_ff @({sens})", self.body, self.label, indent, self.comment
+        )
+
+
+class AlwaysBlock(SvNode):
+    """
+    always_construct (A.6.4) — plain always with explicit event_control (A.6.7):
+
+    .. code-block:: bnf
+
+        always_construct ::= always statement
+        statement        ::= procedural_timing_control_statement
+        procedural_timing_control_statement ::=
+            event_control statement_or_null
+
+    When ``sensitivity_star=True`` (or ``sensitivity`` is empty) emits
+    ``always @(*)``; otherwise the list items are joined with ``or``::
+
+        always @(posedge clk or data_in)
+
+    Prefer ``always_comb`` / ``always_ff`` / ``always_latch`` for new designs;
+    use this class only for legacy or mixed-sensitivity constructs.
+    """
+
+    kind: Literal["always"] = "always"
+    sensitivity: List[SensitivityEvent] = []
+    sensitivity_star: bool = False
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        if self.sensitivity_star or not self.sensitivity:
+            clk_expr = "@(*)"
+        else:
+            sens = " or ".join(e.render() for e in self.sensitivity)
+            clk_expr = f"@({sens})"
+        return _begin_end_items(
+            f"always {clk_expr}", self.body, self.label, indent, self.comment
+        )
+
+
+class InitialBlock(SvNode):
+    """
+    initial_construct (A.6.4):
+
+    .. code-block:: bnf
+
+        initial_construct ::= initial statement_or_null
+
+    Executes once at time zero.  Used for testbench stimulus, memory
+    initialisation, or simulation-only reset sequences.
+
+    .. note::
+        ``initial`` blocks are not synthesisable.  Use ``always_ff`` with a
+        reset condition for synthesisable register initialisation.
+    """
+
+    kind: Literal["initial"] = "initial"
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        return _begin_end_items("initial", self.body, self.label, indent, self.comment)
+
+
+class FinalBlock(SvNode):
+    """
+    final_construct (A.6.4):
+
+    .. code-block:: bnf
+
+        final_construct ::= final function_statement
+
+    Runs exactly once at the end of simulation (time infinity).  Typically
+    used for end-of-test reporting or resource cleanup.
+
+    .. note::
+        ``final`` blocks are not synthesisable.
+    """
+
+    kind: Literal["final"] = "final"
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        return _begin_end_items("final", self.body, self.label, indent, self.comment)
+
+
+class SeqBlock(SvNode):
+    """
+    seq_block (A.6.3) — a named or unnamed ``begin`` … ``end`` block.
+
+    .. code-block:: bnf
+
+        seq_block ::=
+            begin [ : block_identifier ]
+                { block_item_declaration }
+                { statement_or_null }
+            end [ : block_identifier ]
+
+    A ``SeqBlock`` may appear anywhere a procedural statement is legal (inside
+    ``always_*``, ``initial``, or ``final`` bodies, or nested inside another
+    ``SeqBlock``).  It is the only valid way to nest a ``begin``/``end`` group
+    inside a procedural body.
+    """
+
+    kind: Literal["seq_block"] = "seq_block"
+    label: Optional[str] = None
+    body: Annotated[
+        List["ProceduralBodyItem"],
+        BeforeValidator(_coerce_procedural_body),
+    ] = Field(default_factory=list)
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        inner = indent + 1
+        label_sfx = f" : {self.label}" if self.label else ""
+        lines = [f"{pad}begin{label_sfx}" + _inline_comment(self.comment)]
+        for item in self.body:
+            for line in item.render(inner).splitlines():
+                stripped = line.rstrip()
+                lines.append(stripped if stripped else "")
+        lines.append(f"{pad}end{label_sfx}")
+        return "\n".join(lines)
+
+
+# Recursive procedural statement list for ``always_*``, ``initial``, ``final``,
+# and nested ``SeqBlock`` bodies.  Only constructs that are valid *statements*
+# inside a ``begin``/``end`` block are included — module-level constructs such
+# as ``always_*`` / ``initial`` / ``final`` are intentionally excluded.
+
+ProceduralBodyItem = Annotated[
+    Union[
+        RawStatement,
+        CommentBlock,
+        SeqBlock,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+# ─── Generate constructs (A.4.2) ──────────────────────────────────────────────
+#
+# GenerateFor, GenerateIf, and GenerateRegion bodies are typed as
+# ``List[ModuleBodyItem]`` — a forward reference resolved by model_rebuild()
+# at the bottom of this file.
+
+
+class GenerateFor(SvNode):
+    """
+    loop_generate_construct (A.4.2):
+
+    .. code-block:: bnf
+
+        loop_generate_construct ::=
+            for ( genvar_initialization ; genvar_expression ; genvar_iteration )
+            generate_block
+
+        genvar_initialization ::=
+            [ genvar ] genvar_identifier = constant_expression
+
+        generate_block ::=
+            generate_item
+            | [ : label ] begin [ : label ] { generate_item } end [ : label ]
+
+    ``var`` is the genvar identifier (the ``genvar`` keyword is always emitted
+    inline).  ``init``, ``condition``, and ``step`` are constant-expression
+    strings rendered directly into the ``for(…)`` header.
+
+    The ``body`` accepts any ``ModuleBodyItem``  — net declarations, instances,
+    assign statements, always blocks, or nested generate constructs.
+
+    Example::
+
+        for (genvar i = 0; i < N; i++) begin : gen_lanes
+            lane_proc u_lane_i ( ... );
+        end : gen_lanes
+    """
+
+    kind: Literal["generate_for"] = "generate_for"
+    var: str
+    init: str
+    condition: str
+    step: str
+    label: Optional[str] = None
+    body: List["ModuleBodyItem"]  # type: ignore[name-defined]  # forward ref
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        label_sfx = f" : {self.label}" if self.label else ""
+        header = (
+            f"for (genvar {self.var} = {self.init}; {self.condition}; {self.step})"
+        )
+        lines = [f"{pad}{header} begin{label_sfx}" + _inline_comment(self.comment)]
+        for item in self.body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}end{label_sfx}")
+        return "\n".join(lines)
+
+
+class GenerateIf(SvNode):
+    """
+    if_generate_construct (A.4.2):
+
+    .. code-block:: bnf
+
+        if_generate_construct ::=
+            if ( constant_expression ) generate_block [ else generate_block ]
+
+    ``then_body`` is always required; ``else_body`` is optional.  Each branch
+    may carry an independent ``begin : label`` identifier.
+
+    Example::
+
+        if (USE_FAST_PATH) begin : gen_fast
+            fast_cell u_fast ( ... );
+        end : gen_fast
+        else begin : gen_slow
+            slow_cell u_slow ( ... );
+        end : gen_slow
+    """
+
+    kind: Literal["generate_if"] = "generate_if"
+    condition: str
+    then_label: Optional[str] = None
+    then_body: List["ModuleBodyItem"]  # type: ignore[name-defined]
+    else_label: Optional[str] = None
+    else_body: Optional[List["ModuleBodyItem"]] = None  # type: ignore[name-defined]
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        then_sfx = f" : {self.then_label}" if self.then_label else ""
+        lines = [
+            f"{pad}if ({self.condition}) begin{then_sfx}"
+            + _inline_comment(self.comment)
+        ]
+        for item in self.then_body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}end{then_sfx}")
+        if self.else_body is not None:
+            else_sfx = f" : {self.else_label}" if self.else_label else ""
+            lines.append(f"{pad}else begin{else_sfx}")
+            for item in self.else_body:
+                lines.append(item.render(indent + 1))
+            lines.append(f"{pad}end{else_sfx}")
+        return "\n".join(lines)
+
+
+class GenerateRegion(SvNode):
+    """
+    generate_region (A.4.2):
+
+    .. code-block:: bnf
+
+        generate_region ::= generate { generate_item } endgenerate
+
+    Optional explicit wrapper that groups generate constructs under a
+    ``generate … endgenerate`` keyword pair.  The keywords are optional in
+    IEEE 1800-2017 but are commonly required by older tools and improve
+    readability when multiple constructs are grouped.
+
+    The ``body`` accepts any ``ModuleBodyItem``, including nested generate
+    constructs.
+    """
+
+    kind: Literal["generate"] = "generate"
+    body: List["ModuleBodyItem"]  # type: ignore[name-defined]
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        lines = [f"{pad}generate" + _inline_comment(self.comment)]
+        for item in self.body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}endgenerate")
+        return "\n".join(lines)
+
+
+class IfaceGenerateFor(SvNode):
+    """
+    ``for (…) generate`` inside an ``interface`` body (same rules as ``GenerateFor``
+    but items are ``InterfaceBodyItem`` — e.g. modports, nets, nested generate).
+    """
+
+    kind: Literal["iface_generate_for"] = "iface_generate_for"
+    var: str
+    init: str
+    condition: str
+    step: str
+    label: Optional[str] = None
+    body: List["InterfaceBodyItem"]  # type: ignore[name-defined]
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        label_sfx = f" : {self.label}" if self.label else ""
+        header = (
+            f"for (genvar {self.var} = {self.init}; {self.condition}; {self.step})"
+        )
+        lines = [f"{pad}{header} begin{label_sfx}" + _inline_comment(self.comment)]
+        for item in self.body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}end{label_sfx}")
+        return "\n".join(lines)
+
+
+class IfaceGenerateIf(SvNode):
+    """Conditional generate inside an interface body."""
+
+    kind: Literal["iface_generate_if"] = "iface_generate_if"
+    condition: str
+    then_label: Optional[str] = None
+    then_body: List["InterfaceBodyItem"]  # type: ignore[name-defined]
+    else_label: Optional[str] = None
+    else_body: Optional[List["InterfaceBodyItem"]] = None  # type: ignore[name-defined]
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        then_sfx = f" : {self.then_label}" if self.then_label else ""
+        lines = [
+            f"{pad}if ({self.condition}) begin{then_sfx}"
+            + _inline_comment(self.comment)
+        ]
+        for item in self.then_body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}end{then_sfx}")
+        if self.else_body is not None:
+            else_sfx = f" : {self.else_label}" if self.else_label else ""
+            lines.append(f"{pad}else begin{else_sfx}")
+            for item in self.else_body:
+                lines.append(item.render(indent + 1))
+            lines.append(f"{pad}end{else_sfx}")
+        return "\n".join(lines)
+
+
+class IfaceGenerateRegion(SvNode):
+    """``generate … endgenerate`` wrapper inside an interface body."""
+
+    kind: Literal["iface_generate"] = "iface_generate"
+    body: List["InterfaceBodyItem"]  # type: ignore[name-defined]
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        lines = [f"{pad}generate" + _inline_comment(self.comment)]
+        for item in self.body:
+            lines.append(item.render(indent + 1))
+        lines.append(f"{pad}endgenerate")
+        return "\n".join(lines)
+
+
+InterfaceBodyItem = Annotated[
+    Union[
+        LocalparamDecl,
+        NetDecl,
+        TypedVarDecl,
+        AssignStatement,
+        AlwaysComb,
+        AlwaysLatch,
+        AlwaysFf,
+        AlwaysBlock,
+        InitialBlock,
+        FinalBlock,
+        IfaceGenerateFor,
+        IfaceGenerateIf,
+        IfaceGenerateRegion,
+        ModportDecl,
+        RawStatement,
+        CommentBlock,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+class InterfaceDecl(SvNode):
+    """
+    interface_declaration (§25.3):
+
+        ``interface [ lifetime ] interface_identifier … endinterface``
+
+    ANSI-style header with optional ``package_import_declaration`` items (Annex A),
+    then optional parameter port list and interface ports (e.g. clocking inputs),
+    followed by interface items (nets, modports, …).
+
+    ``imports`` holds one ``package_import_item`` string per line (after the
+    ``import`` keyword), e.g. ``"my_pkg::*"`` renders as ``import my_pkg::*;``.
+    """
+
+    kind: Literal["interface"] = "interface"
+    name: str
+    timescale: Optional[str] = None
+    imports: List[str] = []
+    parameters: List[ParamDecl] = []
+    ports: List[PortDecl] = []
+    body: List[InterfaceBodyItem] = []
+    end_label: bool = True
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        inner = _ind(indent + 1)
+        lines: list[str] = []
+
+        if self.timescale:
+            lines.append(f"`timescale {self.timescale}")
+
+        if self.comment:
+            lines.append(f"{pad}// {self.comment}")
+
+        have_imports = bool(self.imports)
+        if have_imports:
+            lines.append(f"{pad}interface {self.name}")
+            for clause in self.imports:
+                lines.append(f"{inner}import {clause};")
+
+        if self.parameters:
+            if have_imports:
+                lines.append(f"{pad}#(")
+            else:
+                lines.append(f"{pad}interface {self.name} #(")
+            for i, p in enumerate(self.parameters):
+                sep = "," if i < len(self.parameters) - 1 else ""
+                lines.append(_with_sep(inner + p.render(), sep))
+            if self.ports:
+                lines.append(f"{pad}) (")
+            else:
+                lines.append(f"{pad});")
+        else:
+            if self.ports:
+                if have_imports:
+                    lines.append(f"{pad}(")
+                else:
+                    lines.append(f"{pad}interface {self.name} (")
+            else:
+                if have_imports:
+                    lines.append(f"{pad};")
+                else:
+                    lines.append(f"{pad}interface {self.name};")
+
+        if self.ports:
+            for i, p in enumerate(self.ports):
+                sep = "," if i < len(self.ports) - 1 else ""
+                lines.append(_with_sep(inner + p.render(), sep))
+            lines.append(f"{pad});")
+
+        _IFACE_BLOCK_TYPES = (
+            AlwaysComb,
+            AlwaysLatch,
+            AlwaysFf,
+            AlwaysBlock,
+            InitialBlock,
+            FinalBlock,
+            IfaceGenerateFor,
+            IfaceGenerateIf,
+            IfaceGenerateRegion,
+        )
+        if self.body:
+            lines.append("")
+            for i, item in enumerate(self.body):
+                lines.append(item.render(indent + 1))
+                if i < len(self.body) - 1:
+                    next_item = self.body[i + 1]
+                    if isinstance(item, _IFACE_BLOCK_TYPES) or isinstance(
+                        next_item, _IFACE_BLOCK_TYPES
+                    ):
+                        lines.append("")
+
+        if self.body:
+            lines.append("")
+        footer = f"{pad}endinterface"
+        if self.end_label:
+            footer += f" : {self.name}"
+        lines.append(footer)
+
+        return "\n".join(lines)
+
+
+# ─── Discriminated union for body items ───────────────────────────────────────
+#
+# Pydantic uses the ``kind`` field value as the discriminator key so that
+# model_validate() selects the right class without trying every branch.
+
+ModuleBodyItem = Annotated[
+    Union[
+        LocalparamDecl,
+        NetDecl,
+        TypedVarDecl,
+        ModuleInst,
+        InterfaceInst,
+        AssignStatement,
+        AlwaysComb,
+        AlwaysLatch,
+        AlwaysFf,
+        AlwaysBlock,
+        InitialBlock,
+        FinalBlock,
+        GenerateFor,
+        GenerateIf,
+        GenerateRegion,
+        RawStatement,
+        CommentBlock,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+# ─── Module declaration (A.1.2 / A.1.3) ──────────────────────────────────────
+
+
+class ModuleDecl(SvNode):
+    """
+    module_declaration with ANSI-style header (A.1.2 / A.1.3):
+
+    Per Annex A, the header may include ``package_import_declaration`` entries
+    after ``module`` ``module_identifier`` and before the optional parameter
+    port list ``#( … )`` and ANSI port list ``( … )``.
+
+    ``imports`` holds one ``package_import_item`` string per line (text after
+    the ``import`` keyword), e.g. ``"shared_types_package::*"`` becomes
+    ``import shared_types_package::*;``.
+
+    When ``imports`` is empty, rendering matches the historical single-line
+    ``module name #(` / ``module name (` / ``module name;`` forms for backward
+    compatibility.
+
+    The ``comment`` field is rendered as a ``//`` line immediately before the
+    ``module`` keyword, serving as a module-level description comment.
+    """
+
+    kind: Literal["module"] = "module"
+    name: str
+    timescale: Optional[str] = None
+    imports: List[str] = []
+    parameters: List[ParamDecl] = []
+    ports: List[ModulePortItem] = []
+    body: List[ModuleBodyItem] = []
+    end_label: bool = True  # emit `: name` after endmodule per LRM §A.1.2
+
+    def render(self, indent: int = 0) -> str:
+        pad = _ind(indent)
+        inner = _ind(indent + 1)
+        lines: list[str] = []
+
+        # ── `timescale compiler directive ─────────────────────────────────────
+        if self.timescale:
+            lines.append(f"`timescale {self.timescale}")
+
+        # ── optional module-level description comment ─────────────────────────
+        if self.comment:
+            lines.append(f"{pad}// {self.comment}")
+
+        have_imports = bool(self.imports)
+        if have_imports:
+            lines.append(f"{pad}module {self.name}")
+            for clause in self.imports:
+                lines.append(f"{inner}import {clause};")
+
+        # ── #( parameter_port_list ) and start of port list ───────────────────
+        if self.parameters:
+            if have_imports:
+                lines.append(f"{pad}#(")
+            else:
+                lines.append(f"{pad}module {self.name} #(")
+            for i, p in enumerate(self.parameters):
+                sep = "," if i < len(self.parameters) - 1 else ""
+                lines.append(_with_sep(inner + p.render(), sep))
+            if self.ports:
+                lines.append(f"{pad}) (")
+            else:
+                lines.append(f"{pad});")
+        else:
+            if self.ports:
+                if have_imports:
+                    lines.append(f"{pad}(")
+                else:
+                    lines.append(f"{pad}module {self.name} (")
+            else:
+                if have_imports:
+                    lines.append(f"{pad};")
+                else:
+                    lines.append(f"{pad}module {self.name};")
+
+        # ── list_of_port_declarations ─────────────────────────────────────────
+        if self.ports:
+            for i, p in enumerate(self.ports):
+                sep = "," if i < len(self.ports) - 1 else ""
+                lines.append(_with_sep(inner + p.render(), sep))
+            lines.append(f"{pad});")
+
+        # ── module body items ─────────────────────────────────────────────────
+        _BLOCK_TYPES = (
+            ModuleInst,
+            InterfaceInst,
+            AlwaysComb, AlwaysLatch, AlwaysFf, AlwaysBlock,
+            InitialBlock, FinalBlock,
+            GenerateFor, GenerateIf, GenerateRegion,
+        )
+        if self.body:
+            lines.append("")
+            for i, item in enumerate(self.body):
+                lines.append(item.render(indent + 1))
+                if i < len(self.body) - 1:
+                    next_item = self.body[i + 1]
+                    if isinstance(item, _BLOCK_TYPES) or isinstance(next_item, _BLOCK_TYPES):
+                        lines.append("")
+
+        # ── endmodule [ : identifier ] ────────────────────────────────────────
+        if self.body:
+            lines.append("")
+        footer = f"{pad}endmodule"
+        if self.end_label:
+            footer += f" : {self.name}"
+        lines.append(footer)
+
+        return "\n".join(lines)
+
+    def declared_signal_names(self) -> set[str]:
+        """
+        Return the set of every name that is legal on the *right-hand side* of a
+        ``PortConn.expression`` inside this module.
+
+        Includes:
+        - All ANSI port names (``PortDecl.name``)
+        - All net/variable declaration names (``NetDecl.name`` in ``body``)
+        - All parameter names (``ParamDecl.name``) — parameters are visible as
+          constant expressions and may legitimately drive parameter ports of
+          child instances.
+        - All localparam names (``LocalparamDecl.name``) — same rationale.
+
+        Does **not** descend into child ``ModuleInst`` items; call this method
+        on the specific ``ModuleDecl`` that contains the instance being checked.
+        """
+        names: set[str] = set()
+        for p in self.ports:
+            names.add(p.name)
+        names.update(p.name for p in self.parameters)
+        for item in self.body:
+            if isinstance(item, NetDecl):
+                names.add(item.name)
+            elif isinstance(item, LocalparamDecl):
+                names.add(item.name)
+            elif isinstance(item, TypedVarDecl):
+                names.add(item.name)
+            elif isinstance(item, InterfaceInst):
+                names.add(item.instance_name)
+        return names
+
+    def validate_instance_connections(
+        self,
+        inst: ModuleInst,
+        child_decl: Optional[ModuleDecl] = None,
+    ) -> list[str]:
+        """
+        Check that every named ``PortConn`` expression in ``inst`` references a
+        name declared in this module.  Returns a list of error strings (empty
+        when all connections are valid).
+
+        Pass ``child_decl`` (the ``ModuleDecl`` of the instantiated module) to
+        enable additional §23.2.2.3 checks:
+
+        - A ``ref`` port may only connect to a variable-type signal (one
+          declared with ``logic``, ``reg``, ``bit``, or an integer type).
+          Connecting it to a net type (``wire``, ``tri``, …) is illegal.
+
+        **Array-of-instances (§23.3.3.5):** when ``inst.instance_dims`` is
+        non-empty the instance is an array.  This method still verifies that
+        every referenced signal name is declared in the parent module.  Full
+        width-distribution checking (whether the connected expression is W wide
+        for replication, or N×W wide for distribution) requires width metadata
+        on ``NetDecl`` / ``PortDecl`` and is not performed here.
+
+        Usage::
+
+            errors = parent.validate_instance_connections(u_child, child_decl)
+            if errors:
+                raise ValueError("\\n".join(errors))
+        """
+        valid = self.declared_signal_names()
+
+        # Map signal name → NetDecl for net-type look-ups (ref port check).
+        parent_nets: dict[str, NetDecl] = {
+            item.name: item
+            for item in self.body
+            if isinstance(item, NetDecl)
+        }
+        # Map port name → PortDecl for the child module (ref direction check).
+        child_ports: dict[str, PortDecl] = (
+            {
+                p.name: p
+                for p in child_decl.ports
+                if isinstance(p, PortDecl)
+            }
+            if child_decl
+            else {}
+        )
+
+        errors: list[str] = []
+
+        def _root_name(expr: PortConnExpr) -> Optional[str]:
+            """Return the base signal name for any named expression."""
+            if isinstance(
+                expr,
+                (SignalRef, BitSelect, PartSelect, IndexedSlice, InterfaceRef, InterfaceIndexedRef),
+            ):
+                return expr.name
+            return None
+
+        def _check_expr(expr: PortConnExpr, port_name: str) -> None:
+            if isinstance(
+                expr,
+                (
+                    SignalRef,
+                    BitSelect,
+                    PartSelect,
+                    IndexedSlice,
+                    InterfaceRef,
+                    InterfaceIndexedRef,
+                ),
+            ):
+                if expr.name not in valid:
+                    errors.append(
+                        f"{inst.instance_name}.{port_name}: "
+                        f"'{expr.name}' is not declared in module '{self.name}'"
+                    )
+            elif isinstance(expr, Concatenation):
+                for part in expr.parts:
+                    _check_expr(part, port_name)
+
+        def _check_ref_port(conn: PortConn) -> None:
+            """§23.2.2.3 — ref ports require a variable, not a net."""
+            port_decl = child_ports.get(conn.port)
+            if port_decl is None or port_decl.direction != "ref":
+                return
+            if conn.expression is None:
+                return
+            sig_name = _root_name(conn.expression)
+            if sig_name is None:
+                return  # concatenation in ref port — caught elsewhere
+            net = parent_nets.get(sig_name)
+            if net is not None and net.net_type in _NET_TYPES:
+                errors.append(
+                    f"{inst.instance_name}.{conn.port}: 'ref' port connected to "
+                    f"net '{sig_name}' (type '{net.net_type}'); "
+                    f"§23.2.2.3 requires a variable type "
+                    f"(logic, reg, bit, integer, …)"
+                )
+
+        for conn in inst.ports:
+            if conn.expression is not None:
+                _check_expr(conn.expression, conn.port)
+            if child_decl:
+                _check_ref_port(conn)
+
+        return errors
+
+
+# ─── Top-level design file ────────────────────────────────────────────────────
+
+
+class SvDesign(BaseModel):
+    """
+    Root object representing a single ``.sv`` file.
+
+    A design file contains an optional file-level description (rendered as a
+    ``//`` header block), zero or more interface declarations, and one or more
+    module declarations.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: Optional[str] = None
+    interfaces: List[InterfaceDecl] = []
+    modules: List[ModuleDecl]
+
+    def render(self) -> str:
+        """Render the entire ``.sv`` file as a string."""
+        sections: list[str] = []
+
+        if self.description:
+            header = "\n".join(f"// {line}" for line in self.description.splitlines())
+            sections.append(header)
+
+        sections.extend(i.render() for i in self.interfaces)
+        sections.extend(m.render() for m in self.modules)
+        return "\n\n".join(sections) + "\n"
+
+
+# ─── Post-definition rebuilds ─────────────────────────────────────────────────
+#
+# ``Concatenation.parts`` uses ``PortConnExpr``, the generate constructs use
+# ``ModuleBodyItem``, and the procedural block classes use ``ProceduralBodyItem``
+# via ``SeqBlock`` — all forward references resolved here.
+
+Concatenation.model_rebuild()
+SeqBlock.model_rebuild()
+AlwaysComb.model_rebuild()
+AlwaysLatch.model_rebuild()
+AlwaysFf.model_rebuild()
+AlwaysBlock.model_rebuild()
+InitialBlock.model_rebuild()
+FinalBlock.model_rebuild()
+GenerateFor.model_rebuild()
+GenerateIf.model_rebuild()
+GenerateRegion.model_rebuild()
+IfaceGenerateFor.model_rebuild()
+IfaceGenerateIf.model_rebuild()
+IfaceGenerateRegion.model_rebuild()

--- a/pysrc/sv_model.py
+++ b/pysrc/sv_model.py
@@ -11,7 +11,7 @@ to emit LRM-compliant SystemVerilog source text.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Callable, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional, Union
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
 
@@ -35,6 +35,65 @@ def _with_sep(rendered: str, sep: str) -> str:
         idx = rendered.index(marker)
         return rendered[:idx] + sep + rendered[idx:]
     return rendered + sep
+
+
+_COMPACT_LINE_MAX: int = 100
+
+
+def set_compact_line_max(n: int) -> None:
+    """Set the column limit used by _render_inst when deciding between a
+    compact one-liner and the standard multi-line format."""
+    global _COMPACT_LINE_MAX
+    _COMPACT_LINE_MAX = n
+
+
+def _render_inst(
+    indent: int,
+    type_name: str,
+    params: list,
+    inst_label: str,
+    ports: list,
+    comment: Optional[str],
+) -> str:
+    """Render a module/interface instantiation.
+
+    When ``comment`` is set it is emitted as a ``// …`` line immediately
+    before the instantiation (at the same indentation level).
+
+    Emits a one-liner when no sub-item carries its own comment and the
+    resulting line fits within ``_COMPACT_LINE_MAX``; otherwise falls back
+    to the standard multi-line format.
+    """
+    pad = _ind(indent)
+    comment_prefix = f"{pad}// {comment}\n" if comment else ""
+
+    # ── attempt compact one-liner ────────────────────────────────────────────
+    no_sub_comments = not any(item.comment for item in list(params) + list(ports))
+    if no_sub_comments:
+        params_str = ", ".join(p.render(0) for p in params)
+        ports_str = ", ".join(p.render(0) for p in ports)
+        if params_str:
+            candidate = f"{pad}{type_name} #({params_str}) {inst_label} ({ports_str});"
+        else:
+            candidate = f"{pad}{type_name} {inst_label} ({ports_str});"
+        if len(candidate) <= _COMPACT_LINE_MAX:
+            return comment_prefix + candidate
+
+    # ── multi-line fallback ──────────────────────────────────────────────────
+    lines: list[str] = []
+    if params:
+        lines.append(f"{pad}{type_name} #(")
+        for i, p in enumerate(params):
+            sep = "," if i < len(params) - 1 else ""
+            lines.append(_with_sep(p.render(indent + 1), sep))
+        lines.append(f"{pad}) {inst_label} (")
+    else:
+        lines.append(f"{pad}{type_name} {inst_label} (")
+    for i, p in enumerate(ports):
+        sep = "," if i < len(ports) - 1 else ""
+        lines.append(_with_sep(p.render(indent + 1), sep))
+    lines.append(f"{pad});")
+    return comment_prefix + "\n".join(lines)
 
 
 def _begin_end(
@@ -95,68 +154,17 @@ class SvNode(BaseModel):
 
     - ``comment``: optional inline ``// comment`` appended to the node's
       primary output line.
-    - ``render_engine``: optional custom render callable invoked *instead of*
-      the built-in renderer.  Signature::
-
-          def my_renderer(node: SvNode, indent: int) -> str: ...
-
-      The callable receives the fully-populated node object (``node``) so it
-      has access to every field as context, and the current indentation level
-      (``indent``).  Set this field programmatically; it is excluded from
-      JSON/YAML serialisation.
     - ``render(indent)`` emits the BNF construct as LRM-formatted text.
     """
 
-    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    model_config = ConfigDict(extra="forbid")
 
     comment: Optional[str] = Field(
         default=None,
         description="Inline // comment appended to this node's primary line.",
     )
-    render_engine: Optional[Callable[["SvNode", int], str]] = Field(
-        default=None,
-        exclude=True,
-        repr=False,
-        description=(
-            "Optional custom render callable invoked instead of the built-in "
-            "renderer.  Signature: ``(node: SvNode, indent: int) -> str``. "
-            "Set programmatically; excluded from serialisation."
-        ),
-    )
-
-    @field_validator("render_engine", mode="before")
-    @classmethod
-    def _validate_render_engine(cls, v: object) -> object:
-        if v is None or callable(v):
-            return v
-        raise ValueError(
-            "render_engine must be a callable with signature "
-            "(node: SvNode, indent: int) -> str, or None"
-        )
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """
-        Wrap every subclass ``render`` implementation so that when
-        ``render_engine`` is set on an instance it is called transparently
-        in place of the built-in method — no per-subclass changes required.
-        """
-        super().__init_subclass__(**kwargs)
-        original = cls.__dict__.get("render")
-        if original is not None:
-            def _make_wrapped(f: Any) -> Any:
-                def _wrapped(self: "SvNode", indent: int = 0) -> str:
-                    if self.render_engine is not None:
-                        return self.render_engine(self, indent)
-                    return f(self, indent)
-                _wrapped.__doc__ = f.__doc__
-                _wrapped.__name__ = f.__name__
-                _wrapped.__qualname__ = f.__qualname__
-                return _wrapped
-            cls.render = _make_wrapped(original)  # type: ignore[method-assign]
 
     def render(self, indent: int = 0) -> str:  # pragma: no cover
-        if self.render_engine is not None:
-            return self.render_engine(self, indent)
         raise NotImplementedError(type(self).__name__)
 
 
@@ -738,31 +746,10 @@ class ModuleInst(SvNode):
     ports: List[PortConn] = []
 
     def render(self, indent: int = 0) -> str:
-        pad = _ind(indent)
-        lines: list[str] = []
-
-        # ── name_of_instance ::= instance_identifier { unpacked_dimension } ──
         inst_label = self.instance_name
         if self.instance_dims:
             inst_label += " " + " ".join(d.render() for d in self.instance_dims)
-
-        # ── type + optional #( parameter_value_assignment ) ──────────────────
-        if self.parameters:
-            lines.append(f"{pad}{self.module_name} #(")
-            for i, p in enumerate(self.parameters):
-                sep = "," if i < len(self.parameters) - 1 else ""
-                lines.append(_with_sep(p.render(indent + 1), sep))
-            lines.append(f"{pad}) {inst_label} (")
-        else:
-            lines.append(f"{pad}{self.module_name} {inst_label} (")
-
-        # ── list_of_port_connections ──────────────────────────────────────────
-        for i, p in enumerate(self.ports):
-            sep = "," if i < len(self.ports) - 1 else ""
-            lines.append(_with_sep(p.render(indent + 1), sep))
-
-        lines.append(f"{pad});" + _inline_comment(self.comment))
-        return "\n".join(lines)
+        return _render_inst(indent, self.module_name, self.parameters, inst_label, self.ports, self.comment)
 
 
 class InterfaceInst(SvNode):
@@ -783,28 +770,10 @@ class InterfaceInst(SvNode):
     ports: List[PortConn] = []
 
     def render(self, indent: int = 0) -> str:
-        pad = _ind(indent)
-        lines: list[str] = []
-
         inst_label = self.instance_name
         if self.instance_dims:
             inst_label += " " + " ".join(d.render() for d in self.instance_dims)
-
-        if self.parameters:
-            lines.append(f"{pad}{self.interface_name} #(")
-            for i, p in enumerate(self.parameters):
-                sep = "," if i < len(self.parameters) - 1 else ""
-                lines.append(_with_sep(p.render(indent + 1), sep))
-            lines.append(f"{pad}) {inst_label} (")
-        else:
-            lines.append(f"{pad}{self.interface_name} {inst_label} (")
-
-        for i, p in enumerate(self.ports):
-            sep = "," if i < len(self.ports) - 1 else ""
-            lines.append(_with_sep(p.render(indent + 1), sep))
-
-        lines.append(f"{pad});" + _inline_comment(self.comment))
-        return "\n".join(lines)
+        return _render_inst(indent, self.interface_name, self.parameters, inst_label, self.ports, self.comment)
 
 
 # ─── Escape hatches ───────────────────────────────────────────────────────────
@@ -1436,7 +1405,8 @@ class InterfaceDecl(SvNode):
     parameters: List[ParamDecl] = []
     ports: List[PortDecl] = []
     body: List[InterfaceBodyItem] = []
-    end_label: bool = True
+    emit_end: bool = True # emit `endinterface` per LRM §A.1.3
+    end_label: bool = True # emit `endinterface : {self.name}` per LRM §A.1.3
 
     def render(self, indent: int = 0) -> str:
         pad = _ind(indent)
@@ -1509,10 +1479,8 @@ class InterfaceDecl(SvNode):
 
         if self.body:
             lines.append("")
-        footer = f"{pad}endinterface"
-        if self.end_label:
-            footer += f" : {self.name}"
-        lines.append(footer)
+        if self.emit_end:
+            lines.append(f"{pad}endinterface : {self.name}" if self.end_label else f"{pad}endinterface")
 
         return "\n".join(lines)
 
@@ -1576,8 +1544,8 @@ class ModuleDecl(SvNode):
     parameters: List[ParamDecl] = []
     ports: List[ModulePortItem] = []
     body: List[ModuleBodyItem] = []
+    emit_end: bool = True # emit `endmodule` per LRM §A.1.2
     end_label: bool = True  # emit `: name` after endmodule per LRM §A.1.2
-    emit_end: bool = True
 
     def render(self, indent: int = 0) -> str:
         pad = _ind(indent)
@@ -1640,22 +1608,31 @@ class ModuleDecl(SvNode):
         )
         if self.body:
             lines.append("")
-            for i, item in enumerate(self.body):
-                lines.append(item.render(indent + 1))
+            rendered_body = [item.render(indent + 1) for item in self.body]
+            for i, (item, rendered) in enumerate(zip(self.body, rendered_body)):
+                lines.append(rendered)
                 if i < len(self.body) - 1:
                     next_item = self.body[i + 1]
+                    next_rendered = rendered_body[i + 1]
                     if isinstance(item, _BLOCK_TYPES) or isinstance(next_item, _BLOCK_TYPES):
-                        lines.append("")
+                        # Omit blank line between consecutive compact (single-line,
+                        # no comment) instances; keep it in all other cases.
+                        curr_compact = (
+                            isinstance(item, (ModuleInst, InterfaceInst))
+                            and "\n" not in rendered
+                        )
+                        next_compact = (
+                            isinstance(next_item, (ModuleInst, InterfaceInst))
+                            and "\n" not in next_rendered
+                        )
+                        if not (curr_compact and next_compact):
+                            lines.append("")
 
         # ── endmodule [ : identifier ] ────────────────────────────────────────
         if self.body:
             lines.append("")
-
         if self.emit_end:
-            footer = f"{pad}endmodule"
-            if self.end_label:
-                footer += f" : {self.name}"
-                lines.append(footer)
+            lines.append(f"{pad}endmodule : {self.name}" if self.end_label else f"{pad}endmodule")
 
         return "\n".join(lines)
 

--- a/pysrc/sv_model.py
+++ b/pysrc/sv_model.py
@@ -81,18 +81,23 @@ def _render_inst(
 
     # ── multi-line fallback ──────────────────────────────────────────────────
     lines: list[str] = []
+    tmp_str: str = ""
     if params:
         lines.append(f"{pad}{type_name} #(")
         for i, p in enumerate(params):
             sep = "," if i < len(params) - 1 else ""
             lines.append(_with_sep(p.render(indent + 1), sep))
-        lines.append(f"{pad}) {inst_label} (")
+        tmp_str = f"{pad}) {inst_label} ("
     else:
-        lines.append(f"{pad}{type_name} {inst_label} (")
+        tmp_str = f"{pad}{type_name} {inst_label} ("
+    if not ports:
+        tmp_str += ");"
+    lines.append(tmp_str)
     for i, p in enumerate(ports):
         sep = "," if i < len(ports) - 1 else ""
         lines.append(_with_sep(p.render(indent + 1), sep))
-    lines.append(f"{pad});")
+    if ports:
+        lines.append(f"{pad});")
     return comment_prefix + "\n".join(lines)
 
 

--- a/pysrc/systemVerilogGeneratorHelper.py
+++ b/pysrc/systemVerilogGeneratorHelper.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from pysrc.arch2codeHelper import printWarning
 
 # Takes a file name f and a block b, checks if they match
-#   returns a string of text modulename
-def fileNameBlockCheck(f, b):
-    out = ''
-    if f != b:
-        printWarning(f'The file name {f} does not match the block name {b}')
-    out += f"//module as defined by block: {b}\n"
-    out += f"module {b}"
-    return out
+#   returns True if they match, prints a warning and returns False if they don't match
+def fileNameBlockCheck(data):
+    moduleSelf = Path(data['fileName']).resolve().stem
+    if moduleSelf != data['blockName']:
+        printWarning(f'The file name {moduleSelf} does not match the block name {data["blockName"]}.'
+            f' This may cause issues with some tools. Consider changing the file name or block name to match.')
+        return False
+    return True
 
 # Takes a project file prj, a starting context sc, and a dictionary for code param passed in user defined packages up
 #   excludeSelf is used to exclude self context references, used when importing packages inside a package

--- a/pysrc/systemVerilogGeneratorHelper.py
+++ b/pysrc/systemVerilogGeneratorHelper.py
@@ -15,13 +15,13 @@ def fileNameBlockCheck(f, b):
 
 # Takes a project file prj, a starting context sc, and a dictionary for code param passed in user defined packages up
 #   excludeSelf is used to exclude self context references, used when importing packages inside a package
-#   returns a string of text that imports automatic packages and user defined packages
-def importPackages(args, prj, sc, data, excludeSelf=False):
-    out = []
+#   returns a list of packages to import
+
+def getImportPackages(args, prj, sc, data, excludeSelf=False):
     moduleSelf = ''
     if excludeSelf:
         moduleSelf = Path(data['fileName']).stem
-    
+
     packageList = []
     if args.fileMapKey:
         fileMapKey = args.fileMapKey
@@ -36,13 +36,19 @@ def importPackages(args, prj, sc, data, excludeSelf=False):
             # https://stackoverflow.com/a/45866399
             if not (packageName == moduleSelf and excludeSelf):
                 packageList.insert(0, packageName)
-    if packageList:
-        out.append(f"// Generated Import package statement(s)")
-        for item in packageList:
-            out.append(f'import {item}::*;')
+
     if data['importPackages']:
-        out.append(f"// User supplied Import package statement(s)")
         for item in data['importPackages'][0]:
-            out.append(f'import {item}::*;')
-            #out.append(f'export {item}::*;')
+            packageList.append(item)
+
+    return packageList
+
+# Takes a project file prj, a starting context sc, and a dictionary for code param passed in user defined packages up
+#   excludeSelf is used to exclude self context references, used when importing packages inside a package
+#   returns a string of text that imports automatic packages and user defined packages
+def importPackages(args, prj, sc, data, excludeSelf=False):
+    out = []
+    packageList = getImportPackages(args, prj, sc, data, excludeSelf)
+    for item in packageList:
+        out.append(f'import {item}::*;')
     return "\n".join(out)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 graphviz>=0.16
 ruamel.base>=1.0.0
-ruamel.yaml 
+ruamel.yaml
 colorama==0.4.4
 jira>=3.5.0
 jinja2
 junit-xml
+pydantic>=2.0

--- a/templates/systemVerilog/apbDecodeModule.py
+++ b/templates/systemVerilog/apbDecodeModule.py
@@ -28,8 +28,11 @@ def render(args, prj, data):
     indentSize = 4
     indent = ' ' * indentSize
 
-    # Pass in the stem of fileName and the blockName
-    out.append(fileNameBlockCheck(Path(data['fileName']).resolve().stem, data['blockName']))
+    # check file name and block name match
+    fileNameBlockCheck(data)
+
+    # Module declaration
+    out.append(f"module {data['blockName']}")
 
     # Packages
     startingContext = prj.data['blocks'][prj.getQualBlock(data['blockName'])]['_context']

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -9,53 +9,31 @@ import pysrc.sv_model as svm
 # prj object
 # data set dict
 def render(args, prj, data):
-    out = []
-    indent = ' ' * 4
-
-    # Pass in the stem of fileName and the blockName
-    out.append(fileNameBlockCheck(Path(data['fileName']).resolve().stem, data['blockName']))
-
-    m = svm.ModuleDecl(name=data['blockName'])
+    m = svm.ModuleDecl(name=data['blockName'], emit_end=False)
 
     # Packages
     startingContext = prj.data['blocks'][prj.getQualBlock(data['blockName'])]['_context']
-    out.append(importPackages(args, prj, startingContext, data))
 
     m.imports = [f"{pkg}::*" for pkg in getImportPackages(args, prj, startingContext, data)]
 
     # Parameters
     if ( prj.data['blocks'][data['qualBlock']]['params'] ):
-        out.append('#(')
-        out.append(",\n".join([f"{indent}parameter {param['param']}" for param in prj.data['blocks'][data['qualBlock']]['params']]))
-        out.append(')')
         for param in prj.data['blocks'][data['qualBlock']]['params']:
             m.parameters.append(svm.ParamDecl(name=param['param']))
 
-    out.append("(")
-
     # Ports
-    m.ports = intf_gen_utils.sv_gen_ports_svm(data, prj, indent, data)
+    m.ports = intf_gen_utils.sv_gen_ports_svm(data, prj, data)
     m.ports += [svm.PortDecl(name='clk', direction='input'), svm.PortDecl(name='rst_n', direction='input')]
-    out.extend(intf_gen_utils.sv_gen_ports(data, prj, indent, data))
 
     #// Interface Instances, needed for between instanced modules inside this module
     m.body.append(svm.CommentBlock(text="Interface Instances, needed for between instanced modules inside this module"))
-
-    out.append(f"{indent}// Interface Instances, needed for between instanced modules inside this module")
 
     for channelType in data["connectDouble"]:
         for key, value in data["connectDouble"][channelType].items():
             intf_type = intf_gen_utils.get_intf_type(value['interfaceType'], data)
             intf_data = intf_gen_utils.get_intf_data(value, prj)
-            s = f"{indent}{intf_type}_if #("
-            params = list()
             if not intf_data['structures']:
                 intf_data['structures'] = []
-            for item in intf_data['structures']:
-                params.append(f".{item['structureType']}({item['structure']})")
-            s += ', '.join(params)
-            s += f") {intf_gen_utils.get_channel_name(value)}();"
-            out.append(s)
             m.body.append(svm.InterfaceInst(
                     instance_name=intf_gen_utils.get_channel_name(value),
                     interface_name=intf_type + '_if',
@@ -63,12 +41,13 @@ def render(args, prj, data):
                 )
             )
 
-    out.append("")
+    m.body.append(svm.CommentBlock(text=""))
 
     #// Memory Interfaces if they exist
     memory_ports = {}
     if data['memories']:
-        out.append(f"{indent}// Memory Interfaces")
+        m.body.append(svm.CommentBlock(text="Memory Interfaces"))
+
         for mem_key, mem_info in data['memories'].items():
             # dualPort with no connection is one with name
             #   and one with Unused
@@ -88,12 +67,21 @@ def render(args, prj, data):
             if mem_info['regAccess']:
                 ports[portCount-1] = mem_info['memory']+'_reg'
             for portName in ports.values():
-                out.append(f"{indent}memory_if #(.data_t({mem_info['structure']}), .addr_t({mem_info['addressStruct']})) {portName}();")
+                m.body.append(
+                    svm.InterfaceInst(
+                        instance_name=portName,
+                        interface_name='memory_if',
+                        parameters=[
+                            svm.ParamConn(param='data_t', value=mem_info['structure']),
+                            svm.ParamConn(param='addr_t', value=mem_info['addressStruct'])
+                        ]
+                    )
+                )
             memory_ports[mem_key] = ports
-        out.append("")
 
     #// Instances
-    out.append("// Instances")
+    m.body.append(svm.CommentBlock(text="Instances"))
+
     for unusedKey, value in data['subBlockInstances'].items():
 
         qualBlockInst = prj.getQualBlock(value['instanceType'])
@@ -105,26 +93,19 @@ def render(args, prj, data):
         else:
             variant_data = None
 
-        inst_params = ' '
         if ( variant_data ):
-            inst_params += '#('
-            inst_params += ", ".join([f".{param['param']}({param['value']})" for param in variant_data])
-            inst_params += ') '
             inst.parameters = [svm.ParamConn(param=param['param'], value=str(param['value'])) for param in variant_data]
 
 
-        out.append(f"{value['instanceType']}{inst_params}{value['instance']} (")
         # Declare connectionMaps that connect to this instance
         for unusedKey2, value2 in data['connectionMaps'].items():
             if (value['instance'] == value2['instance']):
-                out.append(f"{indent}.{value2['instancePortName']} ({value2['parentPortName']}),")
                 inst.ports.append(
                     svm.PortConn(port=value2['instancePortName'], expression=svm.InterfaceRef(name=value2['parentPortName']))
                 )
         # loop through the memory connections that connect to this instance
         for unusedKey2, memValue in data['memoryConnections'].items():
             if (value['instance'] == memValue['instance']):
-                out.append(f"{indent}.{memValue['memory']} ({intf_gen_utils.get_channel_name(memValue)}),")
                 inst.ports.append(
                     svm.PortConn(port=memValue['memory'], expression=svm.InterfaceRef(name=intf_gen_utils.get_channel_name(memValue)))
                 )
@@ -133,21 +114,17 @@ def render(args, prj, data):
             for connKey, connValue in data['connectDouble'][sourceType].items():
                 for end, endValue in connValue['ends'].items():
                     if (value['instance'] == endValue['instance']):
-                        out.append(f"{indent}.{endValue['portName']} ({intf_gen_utils.get_channel_name(connValue)}),")
                         inst.ports.append(
                             svm.PortConn(port=endValue['portName'], expression=svm.InterfaceRef(name=intf_gen_utils.get_channel_name(connValue)))
                         )
         inst.ports.append(svm.PortConn(port='clk', expression=svm.SignalRef(name='clk')))
         inst.ports.append(svm.PortConn(port='rst_n', expression=svm.SignalRef(name='rst_n')))
-        out.append(f"{indent}.clk (clk),\n{indent}.rst_n (rst_n)\n);\n")
 
         m.body.append(inst)
 
-    #print(m.render())
-
     #// Memory Instances if they exist
     if data['memories']:
-        out.append("// Memory Instances")
+        m.body.append(svm.CommentBlock(text="Memory Instances"))
     for mem_key, mem_data in data['memories'].items():
         # memories are currenlty all parameterized behavioral memories
         isLocal = mem_data['local']
@@ -155,13 +132,35 @@ def render(args, prj, data):
         if isLocal:
             memory_type += '_ext'
             localMemInst =f"{mem_data['memory']}Mem"
-            out.append(f"{mem_data['structure']} {localMemInst} [{mem_data['wordLines']}-1:0];")
+            m.body.append(svm.TypedVarDecl(
+                name=localMemInst,
+                user_type=mem_data['structure'],
+                unpacked_dims=[svm.UnpackedDim(msb=f"{mem_data['wordLines']}-1", lsb="0")])
+            )
         memInstName = camelCase('u', mem_data['memory'])
-        out.append(f"{memory_type} #(.DEPTH({mem_data['wordLines']}), .data_t({mem_data['structure']})) {memInstName} (")
+        mem_inst = svm.ModuleInst(
+            instance_name=memInstName,
+            module_name=memory_type,
+            parameters=[
+                svm.ParamConn(param="DEPTH", value=mem_data['wordLines']),
+                svm.ParamConn(param="data_t", value=mem_data['structure'])
+            ]
+        )
+
         for port_key, port_data in memory_ports[mem_key].items():
             port = chr(int(port_key) + ord('A')) if mem_data['memoryType'] == 'dualPort' else ''
-            out.append(f"{indent}.mem_port{port} ({port_data}),")
+            mem_inst.ports.append(
+                svm.PortConn(port=f"mem_port{port}", expression=svm.InterfaceRef(name=port_data))
+            )
         if isLocal:
-            out.append(f"{indent}.mem ({localMemInst}),")
-        out.append(f"{indent}.clk (clk)\n);\n")
-    return "\n".join(out)
+            mem_inst.ports.append(
+                svm.PortConn(port=f"mem", expression=svm.SignalRef(name=localMemInst))
+            )
+
+        mem_inst.ports.append(
+            svm.PortConn(port=f"clk", expression=svm.SignalRef(name="clk"))
+        )
+
+        m.body.append(mem_inst)
+
+    return m.render()

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -1,32 +1,31 @@
 from pathlib import Path
-from pysrc.systemVerilogGeneratorHelper import fileNameBlockCheck, importPackages, getImportPackages
+from pysrc.systemVerilogGeneratorHelper import getImportPackages
 from pysrc.processYaml import camelCase
 import pysrc.intf_gen_utils as intf_gen_utils
-
 import pysrc.sv_model as svm
 
 # args from generator line
 # prj object
 # data set dict
 def render(args, prj, data):
-    m = svm.ModuleDecl(name=data['blockName'], emit_end=False)
+    module = svm.ModuleDecl(name=data['blockName'], emit_end=False)
 
     # Packages
     startingContext = prj.data['blocks'][prj.getQualBlock(data['blockName'])]['_context']
 
-    m.imports = [f"{pkg}::*" for pkg in getImportPackages(args, prj, startingContext, data)]
+    module.imports = [f"{pkg}::*" for pkg in getImportPackages(args, prj, startingContext, data)]
 
     # Parameters
     if ( prj.data['blocks'][data['qualBlock']]['params'] ):
         for param in prj.data['blocks'][data['qualBlock']]['params']:
-            m.parameters.append(svm.ParamDecl(name=param['param']))
+            module.parameters.append(svm.ParamDecl(name=param['param']))
 
     # Ports
-    m.ports = intf_gen_utils.sv_gen_ports_svm(data, prj, data)
-    m.ports += [svm.PortDecl(name='clk', direction='input'), svm.PortDecl(name='rst_n', direction='input')]
+    module.ports = intf_gen_utils.sv_gen_ports_svm(data, prj, data)
+    module.ports += [svm.PortDecl(name='clk', direction='input'), svm.PortDecl(name='rst_n', direction='input')]
 
     #// Interface Instances, needed for between instanced modules inside this module
-    m.body.append(svm.CommentBlock(text="Interface Instances, needed for between instanced modules inside this module"))
+    module.body.append(svm.CommentBlock(text="Interface Instances, needed for between instanced modules inside this module"))
 
     for channelType in data["connectDouble"]:
         for key, value in data["connectDouble"][channelType].items():
@@ -34,19 +33,19 @@ def render(args, prj, data):
             intf_data = intf_gen_utils.get_intf_data(value, prj)
             if not intf_data['structures']:
                 intf_data['structures'] = []
-            m.body.append(svm.InterfaceInst(
+            module.body.append(svm.InterfaceInst(
                     instance_name=intf_gen_utils.get_channel_name(value),
                     interface_name=intf_type + '_if',
                     parameters=[svm.ParamConn(param=item['structureType'], value=item['structure']) for item in intf_data['structures']]
                 )
             )
 
-    m.body.append(svm.CommentBlock(text=""))
+    module.body.append(svm.CommentBlock(text=""))
 
     #// Memory Interfaces if they exist
     memory_ports = {}
     if data['memories']:
-        m.body.append(svm.CommentBlock(text="Memory Interfaces"))
+        module.body.append(svm.CommentBlock(text="Memory Interfaces"))
 
         for mem_key, mem_info in data['memories'].items():
             # dualPort with no connection is one with name
@@ -67,7 +66,7 @@ def render(args, prj, data):
             if mem_info['regAccess']:
                 ports[portCount-1] = mem_info['memory']+'_reg'
             for portName in ports.values():
-                m.body.append(
+                module.body.append(
                     svm.InterfaceInst(
                         instance_name=portName,
                         interface_name='memory_if',
@@ -80,7 +79,7 @@ def render(args, prj, data):
             memory_ports[mem_key] = ports
 
     #// Instances
-    m.body.append(svm.CommentBlock(text="Instances"))
+    module.body.append(svm.CommentBlock(text="Instances"))
 
     for unusedKey, value in data['subBlockInstances'].items():
 
@@ -120,11 +119,11 @@ def render(args, prj, data):
         inst.ports.append(svm.PortConn(port='clk', expression=svm.SignalRef(name='clk')))
         inst.ports.append(svm.PortConn(port='rst_n', expression=svm.SignalRef(name='rst_n')))
 
-        m.body.append(inst)
+        module.body.append(inst)
 
     #// Memory Instances if they exist
     if data['memories']:
-        m.body.append(svm.CommentBlock(text="Memory Instances"))
+        module.body.append(svm.CommentBlock(text="Memory Instances"))
     for mem_key, mem_data in data['memories'].items():
         # memories are currenlty all parameterized behavioral memories
         isLocal = mem_data['local']
@@ -132,7 +131,7 @@ def render(args, prj, data):
         if isLocal:
             memory_type += '_ext'
             localMemInst =f"{mem_data['memory']}Mem"
-            m.body.append(svm.TypedVarDecl(
+            module.body.append(svm.TypedVarDecl(
                 name=localMemInst,
                 user_type=mem_data['structure'],
                 unpacked_dims=[svm.UnpackedDim(msb=f"{mem_data['wordLines']}-1", lsb="0")])
@@ -161,6 +160,6 @@ def render(args, prj, data):
             svm.PortConn(port=f"clk", expression=svm.SignalRef(name="clk"))
         )
 
-        m.body.append(mem_inst)
+        module.body.append(mem_inst)
 
-    return m.render()
+    return module.render()

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -1,7 +1,9 @@
 from pathlib import Path
-from pysrc.systemVerilogGeneratorHelper import fileNameBlockCheck, importPackages
+from pysrc.systemVerilogGeneratorHelper import fileNameBlockCheck, importPackages, getImportPackages
 from pysrc.processYaml import camelCase
 import pysrc.intf_gen_utils as intf_gen_utils
+
+import pysrc.sv_model as svm
 
 # args from generator line
 # prj object
@@ -13,35 +15,54 @@ def render(args, prj, data):
     # Pass in the stem of fileName and the blockName
     out.append(fileNameBlockCheck(Path(data['fileName']).resolve().stem, data['blockName']))
 
+    m = svm.ModuleDecl(name=data['blockName'])
+
     # Packages
     startingContext = prj.data['blocks'][prj.getQualBlock(data['blockName'])]['_context']
     out.append(importPackages(args, prj, startingContext, data))
+
+    m.imports = [f"{pkg}::*" for pkg in getImportPackages(args, prj, startingContext, data)]
 
     # Parameters
     if ( prj.data['blocks'][data['qualBlock']]['params'] ):
         out.append('#(')
         out.append(",\n".join([f"{indent}parameter {param['param']}" for param in prj.data['blocks'][data['qualBlock']]['params']]))
         out.append(')')
+        for param in prj.data['blocks'][data['qualBlock']]['params']:
+            m.parameters.append(svm.ParamDecl(name=param['param']))
 
     out.append("(")
 
     # Ports
+    m.ports = intf_gen_utils.sv_gen_ports_svm(data, prj, indent, data)
+    m.ports += [svm.PortDecl(name='clk', direction='input'), svm.PortDecl(name='rst_n', direction='input')]
     out.extend(intf_gen_utils.sv_gen_ports(data, prj, indent, data))
 
     #// Interface Instances, needed for between instanced modules inside this module
+    m.body.append(svm.CommentBlock(text="Interface Instances, needed for between instanced modules inside this module"))
+
     out.append(f"{indent}// Interface Instances, needed for between instanced modules inside this module")
+
     for channelType in data["connectDouble"]:
         for key, value in data["connectDouble"][channelType].items():
             intf_type = intf_gen_utils.get_intf_type(value['interfaceType'], data)
             intf_data = intf_gen_utils.get_intf_data(value, prj)
             s = f"{indent}{intf_type}_if #("
             params = list()
-            if intf_data['structures']:
-                for item in intf_data['structures']:
-                    params.append(f".{item['structureType']}({item['structure']})")
+            if not intf_data['structures']:
+                intf_data['structures'] = []
+            for item in intf_data['structures']:
+                params.append(f".{item['structureType']}({item['structure']})")
             s += ', '.join(params)
             s += f") {intf_gen_utils.get_channel_name(value)}();"
             out.append(s)
+            m.body.append(svm.InterfaceInst(
+                    instance_name=intf_gen_utils.get_channel_name(value),
+                    interface_name=intf_type + '_if',
+                    parameters=[svm.ParamConn(param=item['structureType'], value=item['structure']) for item in intf_data['structures']]
+                )
+            )
+
     out.append("")
 
     #// Memory Interfaces if they exist
@@ -77,6 +98,8 @@ def render(args, prj, data):
 
         qualBlockInst = prj.getQualBlock(value['instanceType'])
 
+        inst = svm.ModuleInst(instance_name=value['instance'], module_name=value['instanceType'])
+
         if qualBlockInst in prj.data['parameters'].keys():
             variant_data = [v for _,v in prj.data['parameters'][qualBlockInst]['variants'].items() if v['variant'] == value['variant']]
         else:
@@ -87,23 +110,40 @@ def render(args, prj, data):
             inst_params += '#('
             inst_params += ", ".join([f".{param['param']}({param['value']})" for param in variant_data])
             inst_params += ') '
+            inst.parameters = [svm.ParamConn(param=param['param'], value=str(param['value'])) for param in variant_data]
+
 
         out.append(f"{value['instanceType']}{inst_params}{value['instance']} (")
         # Declare connectionMaps that connect to this instance
         for unusedKey2, value2 in data['connectionMaps'].items():
             if (value['instance'] == value2['instance']):
                 out.append(f"{indent}.{value2['instancePortName']} ({value2['parentPortName']}),")
+                inst.ports.append(
+                    svm.PortConn(port=value2['instancePortName'], expression=svm.InterfaceRef(name=value2['parentPortName']))
+                )
         # loop through the memory connections that connect to this instance
         for unusedKey2, memValue in data['memoryConnections'].items():
             if (value['instance'] == memValue['instance']):
                 out.append(f"{indent}.{memValue['memory']} ({intf_gen_utils.get_channel_name(memValue)}),")
+                inst.ports.append(
+                    svm.PortConn(port=memValue['memory'], expression=svm.InterfaceRef(name=intf_gen_utils.get_channel_name(memValue)))
+                )
         # loop through the register connections that connect to this instance
         for sourceType in data['connectDouble']:
             for connKey, connValue in data['connectDouble'][sourceType].items():
                 for end, endValue in connValue['ends'].items():
                     if (value['instance'] == endValue['instance']):
                         out.append(f"{indent}.{endValue['portName']} ({intf_gen_utils.get_channel_name(connValue)}),")
+                        inst.ports.append(
+                            svm.PortConn(port=endValue['portName'], expression=svm.InterfaceRef(name=intf_gen_utils.get_channel_name(connValue)))
+                        )
+        inst.ports.append(svm.PortConn(port='clk', expression=svm.SignalRef(name='clk')))
+        inst.ports.append(svm.PortConn(port='rst_n', expression=svm.SignalRef(name='rst_n')))
         out.append(f"{indent}.clk (clk),\n{indent}.rst_n (rst_n)\n);\n")
+
+        m.body.append(inst)
+
+    #print(m.render())
 
     #// Memory Instances if they exist
     if data['memories']:

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from pysrc.systemVerilogGeneratorHelper import getImportPackages
+from pysrc.systemVerilogGeneratorHelper import fileNameBlockCheck,getImportPackages
 from pysrc.processYaml import camelCase
 import pysrc.intf_gen_utils as intf_gen_utils
 import pysrc.sv_model as svm
@@ -8,6 +8,11 @@ import pysrc.sv_model as svm
 # prj object
 # data set dict
 def render(args, prj, data):
+
+    # check file name and block name match
+    fileNameBlockCheck(data)
+
+    # Module declaration
     module = svm.ModuleDecl(name=data['blockName'], emit_end=False)
 
     # Packages

--- a/templates/systemVerilog/moduleInterfacesInstances.py
+++ b/templates/systemVerilog/moduleInterfacesInstances.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from pysrc.systemVerilogGeneratorHelper import fileNameBlockCheck,getImportPackages
 from pysrc.processYaml import camelCase
 import pysrc.intf_gen_utils as intf_gen_utils


### PR DESCRIPTION
This PR is demonstrating how the template for the systemverilog code generation is being changed to use the sv codegen python package that is based on a data model oriented way to generate 1800-2017 LRM compliant systemverilog code without ever having to write systemverilog code in the template script

This approach creates a clear and language agnostic interface in the template generation that is based on data model oriented way to describe structural systemverilog (pydantic model objects)

For specifying non structural systemverilog, a raw object can be used for user to insert custom blocks of RTL code